### PR TITLE
Bugfix for refresh token scope

### DIFF
--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -11,6 +11,7 @@ from aioauth.utils import (
     create_s256_code_challenge,
     encode_auth_headers,
     generate_token,
+    scope_to_list,
 )
 
 from .conftest import Defaults
@@ -115,6 +116,15 @@ async def test_authorization_code_flow_plan_code_challenge(
     # Check that previous token was revoken
     token_in_db = await db.get_token(request, client_id, access_token, refresh_token)
     assert token_in_db.revoked
+
+    # check that scope is previous scope
+    new_token = await db.get_token(
+        request,
+        client_id,
+        response.content.access_token,
+        response.content.refresh_token,
+    )
+    assert set(scope_to_list(new_token.scope)) == set(scope_to_list(token_in_db.scope))
 
 
 @pytest.mark.asyncio

--- a/tests/test_grant_type.py
+++ b/tests/test_grant_type.py
@@ -1,0 +1,98 @@
+import time
+from typing import Dict
+
+import pytest
+from aioauth.base.database import BaseDB
+from aioauth.config import Settings
+from aioauth.grant_type import RefreshTokenGrantType
+from aioauth.models import AuthorizationCode, Client, Token
+from aioauth.requests import Post, Request
+from aioauth.server import AuthorizationServer
+from aioauth.types import CodeChallengeMethod, GrantType, RequestMethod, ResponseType
+from aioauth.utils import encode_auth_headers
+from tests.models import Defaults
+
+
+@pytest.fixture
+def storage(defaults: Defaults) -> Dict:
+    settings = Settings()
+
+    client = Client(
+        client_id=defaults.client_id,
+        client_secret=defaults.client_secret,
+        grant_types=[
+            GrantType.TYPE_AUTHORIZATION_CODE,
+            GrantType.TYPE_CLIENT_CREDENTIALS,
+            GrantType.TYPE_REFRESH_TOKEN,
+            GrantType.TYPE_PASSWORD,
+        ],
+        redirect_uris=[defaults.redirect_uri],
+        response_types=[ResponseType.TYPE_CODE, ResponseType.TYPE_TOKEN],
+        scope="read write foo",
+    )
+
+    authorization_code = AuthorizationCode(
+        code=defaults.code,
+        client_id=defaults.client_id,
+        response_type=ResponseType.TYPE_CODE,
+        auth_time=int(time.time()),
+        redirect_uri=defaults.redirect_uri,
+        scope="read write",
+        code_challenge_method=CodeChallengeMethod.PLAIN,
+    )
+
+    token = Token(
+        client_id=defaults.client_id,
+        expires_in=settings.TOKEN_EXPIRES_IN,
+        access_token=defaults.access_token,
+        refresh_token=defaults.refresh_token,
+        issued_at=int(time.time()),
+        scope="read write",
+    )
+
+    return {
+        "tokens": [token],
+        "authorization_codes": [authorization_code],
+        "clients": [client],
+    }
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_grant_type(
+    server: AuthorizationServer, defaults: Defaults, db: BaseDB
+):
+    # first create an access token
+
+    client_id = defaults.client_id
+    client_secret = defaults.client_secret
+    request_url = "https://localhost"
+
+    post = Post(
+        grant_type=GrantType.TYPE_REFRESH_TOKEN,
+        refresh_token=defaults.refresh_token,
+        scope="read foo",
+    )
+
+    request = Request(
+        url=request_url,
+        post=post,
+        method=RequestMethod.POST,
+        headers=encode_auth_headers(client_id, client_secret),
+    )
+
+    grant_type = RefreshTokenGrantType(db)
+
+    client = await grant_type.validate_request(request)
+
+    assert client.client_id == client_id
+    assert client.client_secret == client_secret
+
+    # Check that previous token was revoken
+    token_in_db = await db.get_token(
+        request, client_id, defaults.access_token, defaults.refresh_token
+    )
+    assert token_in_db.revoked
+
+    token_response = await grant_type.create_token_response(request)
+
+    assert token_response.scope == "read"


### PR DESCRIPTION
Hi, thank you for your library.

I found a bug though. When refreshing a token the resulting scope should be 

- the scope of the previous token, if no scope was given OR
- a scope that doesn't have a bigger scope than the previous token

see https://www.oauth.com/oauth2-servers/making-authenticated-requests/refreshing-an-access-token/