### PR TITLE
Fixed confusing naming in methods of BaseDB

### DIFF
--- a/src/aioauth/base/database.py
+++ b/src/aioauth/base/database.py
@@ -1,10 +1,9 @@
 import time
 from typing import Optional
 
-from aioauth.types import CodeChallengeMethod, ResponseType
-
 from ..models import AuthorizationCode, Client, Token
 from ..requests import Request
+from ..types import CodeChallengeMethod, ResponseType
 from ..utils import generate_token
 
 
@@ -32,7 +31,7 @@ class BaseDB:
         self,
         request: Request,
         client_id: str,
-        token: Optional[str] = None,
+        access_token: Optional[str] = None,
         refresh_token: Optional[str] = None,
     ) -> Optional[Token]:
         """Gets existing token from the database
@@ -120,7 +119,7 @@ class BaseDB:
             "Method delete_authorization_code must be implemented for AuthorizationCodeGrantType"
         )
 
-    async def revoke_token(self, request: Request, token: str) -> None:
+    async def revoke_token(self, request: Request, refresh_token: str) -> None:
         """Revokes token in database.
 
         This method MUST set `revoked` in True for existing token record.

--- a/src/aioauth/grant_type.py
+++ b/src/aioauth/grant_type.py
@@ -151,7 +151,9 @@ class RefreshTokenGrantType(GrantTypeBase):
         client, old_token = await self.validate_request(request)
 
         # Revoke old token
-        await self.db.revoke_token(request=request, token=old_token.refresh_token)
+        await self.db.revoke_token(
+            request=request, refresh_token=old_token.refresh_token
+        )
 
         # new token should have at max the same scope as the old token
         # (see https://www.oauth.com/oauth2-servers/making-authenticated-requests/refreshing-an-access-token/)

--- a/src/aioauth/models.py
+++ b/src/aioauth/models.py
@@ -1,8 +1,7 @@
 import time
 from typing import List, NamedTuple, Optional, Text
 
-from aioauth.requests import Request
-
+from .requests import Request
 from .types import CodeChallengeMethod, GrantType, ResponseType
 from .utils import create_s256_code_challenge, list_to_scope, scope_to_list
 

--- a/src/aioauth/server.py
+++ b/src/aioauth/server.py
@@ -36,7 +36,7 @@ class AuthorizationServer(BaseAuthorizationServer):
         client_id, _ = decode_auth_headers(request)
 
         token = await self.db.get_token(
-            request=request, client_id=client_id, token=request.post.token
+            request=request, client_id=client_id, access_token=request.post.token
         )
 
         token_response = TokenInactiveIntrospectionResponse()

--- a/tests/classes.py
+++ b/tests/classes.py
@@ -40,17 +40,17 @@ class DB(BaseDB):
         self.storage["tokens"].append(token)
         return token
 
-    async def revoke_token(self, request: Request, token: str) -> None:
+    async def revoke_token(self, request: Request, refresh_token: str) -> None:
         tokens: List[Token] = self.storage.get("tokens", [])
         for key, token_ in enumerate(tokens):
-            if token_.refresh_token == token:
+            if token_.refresh_token == refresh_token:
                 tokens[key] = set_values(token_, {"revoked": True})
 
     async def get_token(
         self,
         request: Request,
         client_id: str,
-        token: Optional[str] = None,
+        access_token: Optional[str] = None,
         refresh_token: Optional[str] = None,
     ) -> Optional[Token]:
         tokens: List[Token] = self.storage.get("tokens", [])
@@ -62,8 +62,8 @@ class DB(BaseDB):
             ):
                 return token_
             if (
-                token is not None
-                and token == token_.access_token
+                access_token is not None
+                and access_token == token_.access_token
                 and client_id == token_.client_id
             ):
                 return token_

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -19,7 +19,7 @@ async def test_db(storage: Dict[str, List]):
         await db.get_token(
             request=request,
             client_id=client.client_id,
-            token=token.access_token,
+            access_token=token.access_token,
             refresh_token=token.refresh_token,
         )
     with pytest.raises(NotImplementedError):
@@ -39,4 +39,4 @@ async def test_db(storage: Dict[str, List]):
             request=request, client_id=client.client_id, code=authorization_code.code
         )
     with pytest.raises(NotImplementedError):
-        await db.revoke_token(request=request, token=token.access_token)
+        await db.revoke_token(request=request, refresh_token=token.refresh_token)


### PR DESCRIPTION
E.g. token was renamed to access_token in `get_token` method.