### PR TITLE
Allow Credentials in POST

### DIFF
--- a/src/aioauth/grant_type.py
+++ b/src/aioauth/grant_type.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Tuple
 
 from .base.request_validator import BaseRequestValidator
 from .errors import (
@@ -41,7 +41,7 @@ class GrantTypeBase(BaseRequestValidator):
     async def validate_request(self, request: Request) -> Client:
         await super().validate_request(request)
 
-        client_id, client_secret = decode_auth_headers(request)
+        client_id, client_secret = self.get_client_credentials(request)
 
         client = await self.db.get_client(
             request, client_id=client_id, client_secret=client_secret
@@ -67,6 +67,15 @@ class GrantTypeBase(BaseRequestValidator):
             raise InvalidScopeError(request=request)
 
         return client
+
+    def get_client_credentials(self, request: Request) -> Tuple[str, str]:
+        client_id = request.post.client_id
+        client_secret = request.post.client_secret
+
+        if client_id is None or client_secret is None:
+            client_id, client_secret = decode_auth_headers(request)
+
+        return client_id, client_secret
 
 
 class AuthorizationCodeGrantType(GrantTypeBase):

--- a/src/aioauth/requests.py
+++ b/src/aioauth/requests.py
@@ -17,6 +17,8 @@ class Query(NamedTuple):
 
 class Post(NamedTuple):
     grant_type: Optional[GrantType] = None
+    client_id: Optional[str] = None
+    client_secret: Optional[str] = None
     redirect_uri: Optional[str] = None
     scope: str = ""
     username: Optional[str] = None

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -79,6 +79,20 @@ EMPTY_KEYS = {
             status_code=HTTPStatus.BAD_REQUEST,
             headers=default_headers,
         ),
+        "client_id": Response(
+            content=ErrorResponse(
+                error=ErrorType.INVALID_GRANT, description="Invalid credentials given.",
+            ),
+            status_code=HTTPStatus.BAD_REQUEST,
+            headers=default_headers,
+        ),
+        "client_secret": Response(
+            content=ErrorResponse(
+                error=ErrorType.INVALID_GRANT, description="Invalid credentials given.",
+            ),
+            status_code=HTTPStatus.BAD_REQUEST,
+            headers=default_headers,
+        ),
         "username": Response(
             content=ErrorResponse(
                 error=ErrorType.INVALID_GRANT, description="Invalid credentials given.",
@@ -164,6 +178,22 @@ INVALID_KEYS = {
         ),
         "refresh_token": Response(
             content=ErrorResponse(error=ErrorType.INVALID_GRANT, description="",),
+            status_code=HTTPStatus.BAD_REQUEST,
+            headers=default_headers,
+        ),
+        "client_id": Response(
+            content=ErrorResponse(
+                error=ErrorType.INVALID_GRANT,
+                description="Invalid client_id parameter value.",
+            ),
+            status_code=HTTPStatus.BAD_REQUEST,
+            headers=default_headers,
+        ),
+        "client_secret": Response(
+            content=ErrorResponse(
+                error=ErrorType.INVALID_GRANT,
+                description="Invalid client_secret parameter value.",
+            ),
             status_code=HTTPStatus.BAD_REQUEST,
             headers=default_headers,
         ),


### PR DESCRIPTION
client_id and client_secret can also be given via POST data. So added client_id and client_secret to Post namedtuple and trying to retrieve them via POST first. Auth Header if they were not found.

https://www.oauth.com/oauth2-servers/access-tokens/client-credentials/