### PR TITLE
refactor: move some business logic out of the db class

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,19 +44,13 @@ class DB(BaseDB):
     creating authorization code, getting a client from the database, etc.
     """
 
-    async def create_token(self, *args, **kwargs) -> Token:
-        """Create token code in db
-        """
-        token = await super().create_token(*args, **kwargs)
-        # NOTE: Save data from token to db here.
-        return token
+    async def save_token(self, token: Token):
+        """Store ALL fields of the Token namedtuple in a db"""
+        ...
 
-    async def create_authorization_code(self, *args, **kwargs) -> AuthorizationCode:
-        """Create authorization code in db
-        """
-        authorization_code = await super().create_authorization_code(*args, **kwargs)
-        # NOTE: Save data from authorization_code to db here.
-        return authorization_code
+    async def save_authorization_code(self, authorization_code: AuthorizationCode):
+        """Store ALL fields of the AuthorizationCode namedtuple in a db"""
+        ...
 
     async def get_token(self, *args, **kwargs) -> Optional[Token]:
         """Get token from the database by provided request from user.
@@ -67,17 +61,19 @@ class DB(BaseDB):
         """
         token_record = ...
 
-        if token_record is not None:
-            return Token(
-                access_token=token_record.access_token,
-                refresh_token=token_record.refresh_token,
-                scope=token_record.scope,
-                issued_at=token_record.issued_at,
-                expires_in=token_record.expires_in,
-                client_id=token_record.client_id,
-                token_type=token_record.token_type,
-                revoked=token_record.revoked
-            )
+        if not token_record:
+            return None
+
+        return Token(
+            access_token=token_record.access_token,
+            refresh_token=token_record.refresh_token,
+            scope=token_record.scope,
+            issued_at=token_record.issued_at,
+            expires_in=token_record.expires_in,
+            client_id=token_record.client_id,
+            token_type=token_record.token_type,
+            revoked=token_record.revoked
+        )
 
     async def get_client(self, *args, **kwargs) -> Optional[Client]:
         """Get client record from the database by provided request from user.
@@ -89,15 +85,17 @@ class DB(BaseDB):
 
         client_record = ...
 
-        if client_record is not None:
-            return Client(
-                client_id=client_record.client_id,
-                client_secret=client_record.client_secret,
-                grant_types=client_record.grant_types,
-                response_types=client_record.response_types,
-                redirect_uris=client_record.redirect_uris,
-                scope=client_record.scope
-            )
+        if not client_record:
+            return None
+
+        return Client(
+            client_id=client_record.client_id,
+            client_secret=client_record.client_secret,
+            grant_types=client_record.grant_types,
+            response_types=client_record.response_types,
+            redirect_uris=client_record.redirect_uris,
+            scope=client_record.scope
+        )
 
     async def revoke_token(self, request: Request, token: str) -> None:
         """Revokes an existing token. The `revoked`

--- a/src/aioauth/base/database.py
+++ b/src/aioauth/base/database.py
@@ -17,7 +17,7 @@ class BaseDB:
         Method is used by response types:
             - ResponseTypeToken
         """
-        return Token(
+        token = Token(
             client_id=client_id,
             expires_in=request.settings.TOKEN_EXPIRES_IN,
             access_token=generate_token(42),
@@ -25,6 +25,14 @@ class BaseDB:
             issued_at=int(time.time()),
             scope=scope,
             revoked=False,
+        )
+        await self.save_token(token)
+        return token
+
+    async def save_token(self, token: Token) -> None:
+        """Store the different fields from the namedtuple into your db"""
+        raise NotImplementedError(
+            "Token MUST be stored in a db. It is a namedtuple and all of its fields should be stored"
         )
 
     async def get_token(
@@ -60,7 +68,7 @@ class BaseDB:
         Method is used by response types:
             - ResponseTypeAuthorizationCode
         """
-        return AuthorizationCode(
+        authorization_code = AuthorizationCode(
             code=generate_token(48),
             client_id=client_id,
             redirect_uri=redirect_uri,
@@ -69,6 +77,15 @@ class BaseDB:
             auth_time=int(time.time()),
             code_challenge_method=code_challenge_method,
             code_challenge=code_challenge,
+        )
+        await self.save_authorization_code(authorization_code)
+        return authorization_code
+
+    async def save_authorization_code(
+        self, authorization_code: AuthorizationCode
+    ) -> None:
+        raise NotImplementedError(
+            "AuthorizationCode MUST be stored in any db. It is a namedtuple and all of its fields should be stored"
         )
 
     async def get_client(

--- a/tests/classes.py
+++ b/tests/classes.py
@@ -3,7 +3,6 @@ from typing import Dict, List, Optional
 from aioauth.base.database import BaseDB
 from aioauth.models import AuthorizationCode, Client, Token
 from aioauth.requests import Request
-from aioauth.types import CodeChallengeMethod, ResponseType
 from tests.utils import set_values
 
 from .models import Defaults
@@ -35,10 +34,8 @@ class DB(BaseDB):
 
         return self._get_by_client_id(client_id)
 
-    async def create_token(self, request: Request, client_id: str, scope: str) -> Token:
-        token = await super().create_token(request, client_id, scope)
+    async def save_token(self, token: Token):
         self.storage["tokens"].append(token)
-        return token
 
     async def revoke_token(self, request: Request, refresh_token: str) -> None:
         tokens: List[Token] = self.storage.get("tokens", [])
@@ -75,27 +72,8 @@ class DB(BaseDB):
         ):
             return True
 
-    async def create_authorization_code(
-        self,
-        request: Request,
-        client_id: str,
-        scope: str,
-        response_type: ResponseType,
-        redirect_uri: str,
-        code_challenge_method: CodeChallengeMethod,
-        code_challenge: str,
-    ) -> AuthorizationCode:
-        authorization_code = await super().create_authorization_code(
-            request,
-            client_id,
-            scope,
-            response_type,
-            redirect_uri,
-            code_challenge_method,
-            code_challenge,
-        )
+    async def save_authorization_code(self, authorization_code: AuthorizationCode):
         self.storage["authorization_codes"].append(authorization_code)
-        return authorization_code
 
     async def get_authorization_code(
         self, request: Request, client_id: str, code: str

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -40,3 +40,9 @@ async def test_db(storage: Dict[str, List]):
         )
     with pytest.raises(NotImplementedError):
         await db.revoke_token(request=request, refresh_token=token.refresh_token)
+
+    with pytest.raises(NotImplementedError):
+        await db.save_token(token)
+
+    with pytest.raises(NotImplementedError):
+        await db.save_authorization_code(authorization_code)


### PR DESCRIPTION
Hello, I was wondering if you'd be willing to accept this PR. I thought the generation of the `Token` namedtuple and the `AuthorizationCode` should not be part of the db interface, when I started with it I was a bit confused.
Now for a user, implementing the interface of `BaseDB` is just about the database.
My current implementation isolates the "save" part, a bit similar to [rest_framework mixins](https://github.com/encode/django-rest-framework/blob/master/rest_framework/mixins.py#L19)

I was also thinking about exposing the in-memory db as part of the library instead of the test, this would also help newcomers to test the library out. 

Let me know what you think.
Regards!