### PR TITLE
Implemented response_mode for OpenID

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Asynchronous OAuth 2.0 framework for Python 3
 
-[![Build Status](https://github.com/aliev/aioauth/workflows/Python%20package/badge.svg?branch=master)](https://github.com/aliev/aioauth/actions/workflows/python-package.yml?query=branch%3Amaster)
+[![Build Status](https://github.com/aliev/aioauth/workflows/Python%20package/badge.svg?branch=master)](https://github.com/aliev/aioauth/actions/workflows/ci.yml?query=branch%3Amaster)
 [![Coverage](https://badgen.net/codecov/c/github/aliev/aioauth)](https://app.codecov.io/gh/aliev/aioauth)
 [![License](https://img.shields.io/github/license/aliev/aioauth)](https://github.com/aliev/aioauth/blob/master/LICENSE)
 [![PyPi](https://badgen.net/pypi/v/aioauth)](https://pypi.org/project/aioauth/)

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ async def to_oauth2_request(request: Request) -> OAuth2Request:
 
 async def to_fastapi_response(oauth2_response: OAuth2Response) -> Response:
     """Converts OAuth2Response instance to fastapi Response instance"""
-    response_content = oauth2_response.content._asdict() if oauth2_response.content is not None else {}
+    response_content = oauth2_response.content
     headers = dict(oauth2_response.headers)
     status_code = oauth2_response.status_code
     content = json.dumps(response_content)

--- a/aioauth/requests.py
+++ b/aioauth/requests.py
@@ -2,7 +2,7 @@ from typing import Any, NamedTuple, Optional
 
 from .config import Settings
 from .structures import CaseInsensitiveDict
-from .types import GrantType, RequestMethod
+from .types import CodeChallengeMethod, GrantType, RequestMethod, ResponseMode
 
 
 class Query(NamedTuple):
@@ -12,8 +12,9 @@ class Query(NamedTuple):
     state: str = ""
     scope: str = ""
     nonce: Optional[str] = None
-    code_challenge_method: Optional[str] = None
+    code_challenge_method: Optional[CodeChallengeMethod] = None
     code_challenge: Optional[str] = None
+    response_mode: Optional[ResponseMode] = None
 
 
 class Post(NamedTuple):

--- a/aioauth/responses.py
+++ b/aioauth/responses.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import NamedTuple, Optional, Union
+from typing import Dict, NamedTuple, Optional
 
 from .constances import default_headers
 from .structures import CaseInsensitiveDict
@@ -91,16 +91,6 @@ class Response(NamedTuple):
         - AuthorizationServer
     """
 
-    content: Optional[
-        Union[
-            ErrorResponse,
-            TokenResponse,
-            NoneResponse,
-            AuthorizationCodeResponse,
-            TokenActiveIntrospectionResponse,
-            TokenInactiveIntrospectionResponse,
-            IdTokenResponse,
-        ]
-    ] = None
+    content: Optional[Dict] = {}
     status_code: HTTPStatus = HTTPStatus.OK
     headers: CaseInsensitiveDict = default_headers

--- a/aioauth/types.py
+++ b/aioauth/types.py
@@ -38,3 +38,9 @@ class RequestMethod(str, Enum):
 class CodeChallengeMethod(str, Enum):
     PLAIN = "plain"
     S256 = "S256"
+
+
+class ResponseMode(str, Enum):
+    MODE_QUERY = "query"
+    MODE_FORM_POST = "form_post"
+    MODE_FRAGMENT = "fragment"

--- a/aioauth/utils.py
+++ b/aioauth/utils.py
@@ -147,14 +147,16 @@ def catch_errors_and_unavailability(f) -> Callable:
             content = ErrorResponse(error=exc.error, description=exc.description)
             log.exception("Exception caught while processing request.")
             return Response(
-                content=content, status_code=exc.status_code, headers=exc.headers
+                content=content._asdict(),
+                status_code=exc.status_code,
+                headers=exc.headers,
             )
         except Exception:
             error = ServerError(request=request)
             log.exception("Exception caught while processing request.")
             content = ErrorResponse(error=error.error, description=error.description)
             return Response(
-                content=content,
+                content=content._asdict(),
                 status_code=error.status_code,
                 headers=error.headers,
             )

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -51,7 +51,7 @@ async def test_invalid_token(server: AuthorizationServer, defaults: Defaults):
         headers=encode_auth_headers(client_id, client_secret),
     )
     response = await server.create_token_introspection_response(request)
-    assert not response.content.active
+    assert not response.content["active"]
     assert response.status_code == HTTPStatus.OK
 
 
@@ -84,7 +84,7 @@ async def test_expired_token(
 
     response = await server.create_token_introspection_response(request)
     assert response.status_code == HTTPStatus.OK
-    assert not response.content.active
+    assert not response.content["active"]
 
 
 @pytest.mark.asyncio
@@ -109,7 +109,7 @@ async def test_valid_token(
 
     response = await server.create_token_introspection_response(request)
     assert response.status_code == HTTPStatus.OK
-    assert response.content.active
+    assert response.content["active"]
 
 
 @pytest.mark.asyncio
@@ -148,7 +148,7 @@ async def test_introspect_revoked_token(
         headers=encode_auth_headers(client_id, client_secret),
     )
     response = await server.create_token_introspection_response(request)
-    assert not response.content.active, "The refresh_token must be revoked"
+    assert not response.content["active"], "The refresh_token must be revoked"
 
 
 @pytest.mark.asyncio
@@ -157,4 +157,4 @@ async def test_endpoint_availability(db_class: Type[BaseStorage]):
     request = Request(method=RequestMethod.POST, settings=Settings(AVAILABLE=False))
     response = await server.create_token_introspection_response(request)
     assert response.status_code == HTTPStatus.BAD_REQUEST
-    assert response.content.error == ErrorType.TEMPORARILY_UNAVAILABLE
+    assert response.content["error"] == ErrorType.TEMPORARILY_UNAVAILABLE

--- a/tests/test_request_validator.py
+++ b/tests/test_request_validator.py
@@ -66,7 +66,7 @@ async def test_invalid_client_credentials(
 
     response = await server.create_token_response(request)
     assert response.status_code == HTTPStatus.BAD_REQUEST
-    assert response.content.error == ErrorType.INVALID_REQUEST
+    assert response.content["error"] == ErrorType.INVALID_REQUEST
 
 
 @pytest.mark.asyncio
@@ -91,7 +91,7 @@ async def test_invalid_scope(server: AuthorizationServer, defaults: Defaults):
 
     response = await server.create_token_response(request)
     assert response.status_code == HTTPStatus.BAD_REQUEST
-    assert response.content.error == ErrorType.INVALID_SCOPE
+    assert response.content["error"] == ErrorType.INVALID_SCOPE
 
 
 @pytest.mark.asyncio
@@ -124,7 +124,7 @@ async def test_invalid_grant_type(
 
     response = await server.create_token_response(request)
     assert response.status_code == HTTPStatus.BAD_REQUEST
-    assert response.content.error == ErrorType.UNAUTHORIZED_CLIENT
+    assert response.content["error"] == ErrorType.UNAUTHORIZED_CLIENT
 
 
 @pytest.mark.asyncio
@@ -160,7 +160,7 @@ async def test_invalid_response_type(
     )
     response = await server.create_authorization_response(request)
     assert response.status_code == HTTPStatus.BAD_REQUEST
-    assert response.content.error == ErrorType.UNSUPPORTED_RESPONSE_TYPE
+    assert response.content["error"] == ErrorType.UNSUPPORTED_RESPONSE_TYPE
 
 
 @pytest.mark.asyncio
@@ -182,7 +182,7 @@ async def test_anonymous_user(server: AuthorizationServer, defaults: Defaults, s
     request = Request(url=request_url, query=query, method=RequestMethod.GET)
     response = await server.create_authorization_response(request)
     assert response.status_code == HTTPStatus.UNAUTHORIZED
-    assert response.content.error == ErrorType.INVALID_CLIENT
+    assert response.content["error"] == ErrorType.INVALID_CLIENT
 
 
 @pytest.mark.asyncio
@@ -213,7 +213,7 @@ async def test_expired_authorization_code(
     )
     response = await server.create_token_response(request)
     assert response.status_code == HTTPStatus.BAD_REQUEST
-    assert response.content.error == ErrorType.INVALID_GRANT
+    assert response.content["error"] == ErrorType.INVALID_GRANT
 
 
 @pytest.mark.asyncio
@@ -242,4 +242,4 @@ async def test_expired_refresh_token(
     )
     response = await server.create_token_response(request)
     assert response.status_code == HTTPStatus.BAD_REQUEST
-    assert response.content.error == ErrorType.INVALID_GRANT
+    assert response.content["error"] == ErrorType.INVALID_GRANT

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -13,7 +13,7 @@ EMPTY_KEYS = {
             content=ErrorResponse(
                 error=ErrorType.INVALID_REQUEST,
                 description="Missing client_id parameter.",
-            ),
+            )._asdict(),
             status_code=HTTPStatus.BAD_REQUEST,
             headers=default_headers,
         ),
@@ -21,7 +21,7 @@ EMPTY_KEYS = {
             content=ErrorResponse(
                 error=ErrorType.INVALID_REQUEST,
                 description="Missing response_type parameter.",
-            ),
+            )._asdict(),
             status_code=HTTPStatus.BAD_REQUEST,
             headers=default_headers,
         ),
@@ -29,7 +29,7 @@ EMPTY_KEYS = {
             content=ErrorResponse(
                 error=ErrorType.INVALID_REQUEST,
                 description="Mismatching redirect URI.",
-            ),
+            )._asdict(),
             status_code=HTTPStatus.BAD_REQUEST,
             headers=default_headers,
         ),
@@ -37,7 +37,7 @@ EMPTY_KEYS = {
             content=ErrorResponse(
                 error=ErrorType.INVALID_REQUEST,
                 description="Code challenge required.",
-            ),
+            )._asdict(),
             status_code=HTTPStatus.BAD_REQUEST,
             headers=default_headers,
         ),
@@ -45,7 +45,7 @@ EMPTY_KEYS = {
             content=ErrorResponse(
                 error=ErrorType.INVALID_REQUEST,
                 description="Nonce required for response_type id_token.",
-            ),
+            )._asdict(),
             status_code=HTTPStatus.BAD_REQUEST,
             headers=default_headers,
         ),
@@ -55,7 +55,7 @@ EMPTY_KEYS = {
             content=ErrorResponse(
                 error=ErrorType.INVALID_REQUEST,
                 description="Request is missing grant type.",
-            ),
+            )._asdict(),
             status_code=HTTPStatus.BAD_REQUEST,
             headers=default_headers,
         ),
@@ -63,7 +63,7 @@ EMPTY_KEYS = {
             content=ErrorResponse(
                 error=ErrorType.INVALID_REQUEST,
                 description="Mismatching redirect URI.",
-            ),
+            )._asdict(),
             status_code=HTTPStatus.BAD_REQUEST,
             headers=default_headers,
         ),
@@ -71,7 +71,7 @@ EMPTY_KEYS = {
             content=ErrorResponse(
                 error=ErrorType.INVALID_REQUEST,
                 description="Missing code parameter.",
-            ),
+            )._asdict(),
             status_code=HTTPStatus.BAD_REQUEST,
             headers=default_headers,
         ),
@@ -79,7 +79,7 @@ EMPTY_KEYS = {
             content=ErrorResponse(
                 error=ErrorType.INVALID_REQUEST,
                 description="Missing refresh token parameter.",
-            ),
+            )._asdict(),
             status_code=HTTPStatus.BAD_REQUEST,
             headers=default_headers,
         ),
@@ -87,7 +87,7 @@ EMPTY_KEYS = {
             content=ErrorResponse(
                 error=ErrorType.INVALID_REQUEST,
                 description="Code verifier required.",
-            ),
+            )._asdict(),
             status_code=HTTPStatus.BAD_REQUEST,
             headers=default_headers,
         ),
@@ -95,7 +95,7 @@ EMPTY_KEYS = {
             content=ErrorResponse(
                 error=ErrorType.INVALID_CLIENT,
                 description="",
-            ),
+            )._asdict(),
             status_code=HTTPStatus.UNAUTHORIZED,
             headers=CaseInsensitiveDict({"www-authenticate": "Basic"}),
         ),
@@ -103,7 +103,7 @@ EMPTY_KEYS = {
             content=ErrorResponse(
                 error=ErrorType.INVALID_CLIENT,
                 description="",
-            ),
+            )._asdict(),
             status_code=HTTPStatus.UNAUTHORIZED,
             headers=CaseInsensitiveDict({"www-authenticate": "Basic"}),
         ),
@@ -111,7 +111,7 @@ EMPTY_KEYS = {
             content=ErrorResponse(
                 error=ErrorType.INVALID_GRANT,
                 description="Invalid credentials given.",
-            ),
+            )._asdict(),
             status_code=HTTPStatus.BAD_REQUEST,
             headers=default_headers,
         ),
@@ -119,7 +119,7 @@ EMPTY_KEYS = {
             content=ErrorResponse(
                 error=ErrorType.INVALID_GRANT,
                 description="Invalid credentials given.",
-            ),
+            )._asdict(),
             status_code=HTTPStatus.BAD_REQUEST,
             headers=default_headers,
         ),
@@ -132,7 +132,7 @@ INVALID_KEYS = {
             content=ErrorResponse(
                 error=ErrorType.INVALID_REQUEST,
                 description="Invalid client_id parameter value.",
-            ),
+            )._asdict(),
             status_code=HTTPStatus.BAD_REQUEST,
             headers=default_headers,
         ),
@@ -140,7 +140,7 @@ INVALID_KEYS = {
             content=ErrorResponse(
                 error=ErrorType.UNSUPPORTED_RESPONSE_TYPE,
                 description="",
-            ),
+            )._asdict(),
             status_code=HTTPStatus.BAD_REQUEST,
             headers=default_headers,
         ),
@@ -148,7 +148,7 @@ INVALID_KEYS = {
             content=ErrorResponse(
                 error=ErrorType.INVALID_REQUEST,
                 description="Invalid redirect URI.",
-            ),
+            )._asdict(),
             status_code=HTTPStatus.BAD_REQUEST,
             headers=default_headers,
         ),
@@ -156,7 +156,7 @@ INVALID_KEYS = {
             content=ErrorResponse(
                 error=ErrorType.INVALID_REQUEST,
                 description="Transform algorithm not supported.",
-            ),
+            )._asdict(),
             status_code=HTTPStatus.BAD_REQUEST,
             headers=default_headers,
         ),
@@ -164,7 +164,7 @@ INVALID_KEYS = {
             content=ErrorResponse(
                 error=ErrorType.INVALID_SCOPE,
                 description="",
-            ),
+            )._asdict(),
             status_code=HTTPStatus.BAD_REQUEST,
             headers=default_headers,
         ),
@@ -174,7 +174,7 @@ INVALID_KEYS = {
             content=ErrorResponse(
                 error=ErrorType.UNSUPPORTED_GRANT_TYPE,
                 description="",
-            ),
+            )._asdict(),
             status_code=HTTPStatus.BAD_REQUEST,
             headers=default_headers,
         ),
@@ -182,7 +182,7 @@ INVALID_KEYS = {
             content=ErrorResponse(
                 error=ErrorType.INVALID_REQUEST,
                 description="Invalid redirect URI.",
-            ),
+            )._asdict(),
             status_code=HTTPStatus.BAD_REQUEST,
             headers=default_headers,
         ),
@@ -190,7 +190,7 @@ INVALID_KEYS = {
             content=ErrorResponse(
                 error=ErrorType.INVALID_GRANT,
                 description="",
-            ),
+            )._asdict(),
             status_code=HTTPStatus.BAD_REQUEST,
             headers=default_headers,
         ),
@@ -198,7 +198,7 @@ INVALID_KEYS = {
             content=ErrorResponse(
                 error=ErrorType.MISMATCHING_STATE,
                 description="CSRF Warning! State not equal in request and response.",
-            ),
+            )._asdict(),
             status_code=HTTPStatus.BAD_REQUEST,
             headers=default_headers,
         ),
@@ -206,7 +206,7 @@ INVALID_KEYS = {
             content=ErrorResponse(
                 error=ErrorType.INVALID_GRANT,
                 description="",
-            ),
+            )._asdict(),
             status_code=HTTPStatus.BAD_REQUEST,
             headers=default_headers,
         ),
@@ -214,7 +214,7 @@ INVALID_KEYS = {
             content=ErrorResponse(
                 error=ErrorType.INVALID_REQUEST,
                 description="Invalid client_id parameter value.",
-            ),
+            )._asdict(),
             status_code=HTTPStatus.BAD_REQUEST,
             headers=default_headers,
         ),
@@ -222,7 +222,7 @@ INVALID_KEYS = {
             content=ErrorResponse(
                 error=ErrorType.INVALID_REQUEST,
                 description="Invalid client_id parameter value.",
-            ),
+            )._asdict(),
             status_code=HTTPStatus.BAD_REQUEST,
             headers=default_headers,
         ),
@@ -230,7 +230,7 @@ INVALID_KEYS = {
             content=ErrorResponse(
                 error=ErrorType.INVALID_GRANT,
                 description="Invalid credentials given.",
-            ),
+            )._asdict(),
             status_code=HTTPStatus.BAD_REQUEST,
             headers=default_headers,
         ),
@@ -238,7 +238,7 @@ INVALID_KEYS = {
             content=ErrorResponse(
                 error=ErrorType.INVALID_GRANT,
                 description="Invalid credentials given.",
-            ),
+            )._asdict(),
             status_code=HTTPStatus.BAD_REQUEST,
             headers=default_headers,
         ),


### PR DESCRIPTION
As part of the OpenID implementation, the ability to specify response_mode has been added.

You can read [here](https://openid.net/specs/oauth-v2-multiple-response-types-1_0.html#ResponseModes) more information about `response_mode`

Additional changes:

`Response.content` now returns a dictionary (empty content returns empty dictionary).
This was done so that the user of the library does not have to manually convert the object into a dictionary.