### PR TITLE
Removed Python 3.6 support and added Python 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Coverage](https://badgen.net/codecov/c/github/aliev/aioauth)](https://app.codecov.io/gh/aliev/aioauth)
 [![License](https://img.shields.io/github/license/aliev/aioauth)](https://github.com/aliev/aioauth/blob/master/LICENSE)
 [![PyPi](https://badgen.net/pypi/v/aioauth)](https://pypi.org/project/aioauth/)
-[![Python 3.6](https://img.shields.io/badge/python-3.6-blue.svg)](https://www.python.org/downloads/release/python-360/)
+[![Python 3.7](https://img.shields.io/badge/python-3.7-blue.svg)](https://www.python.org/downloads/release/python-370/)
 
 `aioauth` implements [OAuth 2.0 protocol](https://tools.ietf.org/html/rfc6749) and can be used in asynchronous frameworks like [FastAPI / Starlette](https://github.com/tiangolo/fastapi), [aiohttp](https://github.com/aio-libs/aiohttp). It can work with any databases like `MongoDB`, `PostgreSQL`, `MySQL` and ORMs like [gino](https://python-gino.org/), [sqlalchemy](https://www.sqlalchemy.org/) or [databases](https://pypi.org/project/databases/) over simple [BaseStorage](aioauth/storage.py) interface.
 

--- a/setup.py
+++ b/setup.py
@@ -29,9 +29,10 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
     "Topic :: Internet :: WWW/HTTP :: HTTP Servers",
     "Topic :: Internet :: WWW/HTTP",
 ]
@@ -69,7 +70,7 @@ setup(
     url=about["__url__"],
     license=about["__license__"],
     package_data={"aioauth": ["py.typed"]},
-    python_requires=">=3.6.0",
+    python_requires=">=3.7.0",
     classifiers=classifiers,
     extras_require={
         "fastapi": ["aioauth-fastapi>=0.0.1"],


### PR DESCRIPTION
This PR is preparation for migrating to dataclasses from `NamedTuple`.

Changes affected by this PR:

* Removed Python 3.6 support.
* Added Python 3.10 support.

The reasons of removing Python 3.6 support in the next major release:

* [Python 3.6 is no longer officially supported](https://endoflife.date/python).
* Python 3.6 doesn't support dataclasses.

For more information please check these links:

More information is here: https://github.com/aliev/aioauth/pull/58 https://github.com/aliev/aioauth/discussions/57