### PR TITLE
fix: replaced --stric to --strict-markers in pytest options

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ search = "{current_version}"
 replace = "{new_version}"
 
 [tool:pytest]
-addopts = -s --strict -vv --cache-clear --maxfail=1 --cov=aioauth --cov-report=term --cov-report=html --cov-branch --no-cov-on-fail
+addopts = -s --strict-markers -vv --cache-clear --maxfail=1 --cov=aioauth --cov-report=term --cov-report=html --cov-branch --no-cov-on-fail
 
 [coverage:run]
 branch = True


### PR DESCRIPTION
In order to get rid of this warning:

```
PytestDeprecationWarning: The --strict option is deprecated, use --strict-markers instead.
    self.issue_config_time_warning(
```

`--strict` option was replaced to `--strict-markers`