### PR TITLE
fix: mypy errors on custom models

### DIFF
--- a/aioauth/collections.py
+++ b/aioauth/collections.py
@@ -33,8 +33,8 @@ class HTTPHeaderDict(UserDict):
         d['hElLo'] == 'world' # >>> True
     """
 
-    def __setitem__(self, key, value):
+    def __setitem__(self, key: str, value: str):
         super().__setitem__(key.lower(), value)
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: str):
         return super().__getitem__(key.lower())

--- a/aioauth/errors.py
+++ b/aioauth/errors.py
@@ -14,7 +14,7 @@ from urllib.parse import urljoin
 
 from .collections import HTTPHeaderDict
 from .constances import default_headers
-from .requests import Request
+from .requests import BaseRequest
 from .types import ErrorType
 
 
@@ -29,7 +29,7 @@ class OAuth2Error(Exception):
 
     def __init__(
         self,
-        request: Request,
+        request: BaseRequest,
         description: Optional[str] = None,
         headers: Optional[HTTPHeaderDict] = None,
     ):

--- a/aioauth/errors.py
+++ b/aioauth/errors.py
@@ -11,6 +11,7 @@ Errors used throughout the project.
 from http import HTTPStatus
 from typing import Generic, Optional
 from urllib.parse import urljoin
+from typing_extensions import Literal
 
 from .collections import HTTPHeaderDict
 from .constances import default_headers
@@ -55,7 +56,7 @@ class MethodNotAllowedError(OAuth2Error[TRequest]):
 
     description = "HTTP method is not allowed."
     status_code: HTTPStatus = HTTPStatus.METHOD_NOT_ALLOWED
-    error = ErrorType.METHOD_IS_NOT_ALLOWED
+    error: Literal["method_is_not_allowed"] = "method_is_not_allowed"
 
 
 class InvalidRequestError(OAuth2Error[TRequest]):
@@ -65,7 +66,7 @@ class InvalidRequestError(OAuth2Error[TRequest]):
     otherwise malformed.
     """
 
-    error = ErrorType.INVALID_REQUEST
+    error: Literal["invalid_request"] = "invalid_request"
 
 
 class InvalidClientError(OAuth2Error[TRequest]):
@@ -81,7 +82,7 @@ class InvalidClientError(OAuth2Error[TRequest]):
     client.
     """
 
-    error = ErrorType.INVALID_CLIENT
+    error: Literal["invalid_client"] = "invalid_client"
     status_code: HTTPStatus = HTTPStatus.UNAUTHORIZED
 
 
@@ -89,7 +90,7 @@ class InsecureTransportError(OAuth2Error[TRequest]):
     """An exception will be thrown if the current request is not secure."""
 
     description = "OAuth 2 MUST utilize https."
-    error = ErrorType.INSECURE_TRANSPORT
+    error: Literal["insecure_transport"] = "insecure_transport"
 
 
 class UnsupportedGrantTypeError(OAuth2Error[TRequest]):
@@ -98,7 +99,7 @@ class UnsupportedGrantTypeError(OAuth2Error[TRequest]):
     server.
     """
 
-    error = ErrorType.UNSUPPORTED_GRANT_TYPE
+    error: Literal["unsupported_grant_type"] = "unsupported_grant_type"
 
 
 class UnsupportedResponseTypeError(OAuth2Error[TRequest]):
@@ -107,7 +108,7 @@ class UnsupportedResponseTypeError(OAuth2Error[TRequest]):
     code using this method.
     """
 
-    error = ErrorType.UNSUPPORTED_RESPONSE_TYPE
+    error: Literal["unsupported_response_type"] = "unsupported_response_type"
 
 
 class InvalidGrantError(OAuth2Error[TRequest]):
@@ -120,14 +121,14 @@ class InvalidGrantError(OAuth2Error[TRequest]):
     See `RFC6749 section 5.2 <https://tools.ietf.org/html/rfc6749#section-5.2>`_.
     """
 
-    error = ErrorType.INVALID_GRANT
+    error: Literal["invalid_grant"] = "invalid_grant"
 
 
 class MismatchingStateError(OAuth2Error[TRequest]):
     """Unable to securely verify the integrity of the request and response."""
 
     description = "CSRF Warning! State not equal in request and response."
-    error = ErrorType.MISMATCHING_STATE
+    error: Literal["mismatching_state"] = "mismatching_state"
 
 
 class UnauthorizedClientError(OAuth2Error[TRequest]):
@@ -136,7 +137,7 @@ class UnauthorizedClientError(OAuth2Error[TRequest]):
     grant type.
     """
 
-    error = ErrorType.UNAUTHORIZED_CLIENT
+    error: Literal["unauthorized_client"] = "unauthorized_client"
 
 
 class InvalidScopeError(OAuth2Error[TRequest]):
@@ -147,7 +148,7 @@ class InvalidScopeError(OAuth2Error[TRequest]):
     See `RFC6749 section 5.2 <https://tools.ietf.org/html/rfc6749#section-5.2>`_.
     """
 
-    error = ErrorType.INVALID_SCOPE
+    error: Literal["invalid_scope"] = "invalid_scope"
 
 
 class ServerError(OAuth2Error[TRequest]):
@@ -158,7 +159,7 @@ class ServerError(OAuth2Error[TRequest]):
     to the client via a HTTP redirect.)
     """
 
-    error = ErrorType.SERVER_ERROR
+    error: Literal["temporarily_unavailable"] = "temporarily_unavailable"
 
 
 class TemporarilyUnavailableError(OAuth2Error[TRequest]):
@@ -169,4 +170,4 @@ class TemporarilyUnavailableError(OAuth2Error[TRequest]):
     status code cannot be returned to the client via a HTTP redirect.)
     """
 
-    error = ErrorType.TEMPORARILY_UNAVAILABLE
+    error: Literal["temporarily_unavailable"] = "temporarily_unavailable"

--- a/aioauth/errors.py
+++ b/aioauth/errors.py
@@ -9,16 +9,16 @@ Errors used throughout the project.
 """
 
 from http import HTTPStatus
-from typing import Optional
+from typing import Generic, Optional
 from urllib.parse import urljoin
 
 from .collections import HTTPHeaderDict
 from .constances import default_headers
-from .requests import BaseRequest
+from .requests import TRequest
 from .types import ErrorType
 
 
-class OAuth2Error(Exception):
+class OAuth2Error(Exception, Generic[TRequest]):
     """Base exception that all other exceptions inherit from."""
 
     error: ErrorType
@@ -29,7 +29,7 @@ class OAuth2Error(Exception):
 
     def __init__(
         self,
-        request: BaseRequest,
+        request: TRequest,
         description: Optional[str] = None,
         headers: Optional[HTTPHeaderDict] = None,
     ):
@@ -47,7 +47,7 @@ class OAuth2Error(Exception):
         super().__init__(f"({self.error}) {self.description}")
 
 
-class MethodNotAllowedError(OAuth2Error):
+class MethodNotAllowedError(OAuth2Error[TRequest]):
     """
     The request is valid, but the method trying to be accessed is not
     available to the resource owner.
@@ -58,7 +58,7 @@ class MethodNotAllowedError(OAuth2Error):
     error = ErrorType.METHOD_IS_NOT_ALLOWED
 
 
-class InvalidRequestError(OAuth2Error):
+class InvalidRequestError(OAuth2Error[TRequest]):
     """
     The request is missing a required parameter, includes an invalid
     parameter value, includes a parameter more than once, or is
@@ -68,7 +68,7 @@ class InvalidRequestError(OAuth2Error):
     error = ErrorType.INVALID_REQUEST
 
 
-class InvalidClientError(OAuth2Error):
+class InvalidClientError(OAuth2Error[TRequest]):
     """
     Client authentication failed (e.g. unknown client, no client
     authentication included, or unsupported authentication method).
@@ -85,14 +85,14 @@ class InvalidClientError(OAuth2Error):
     status_code: HTTPStatus = HTTPStatus.UNAUTHORIZED
 
 
-class InsecureTransportError(OAuth2Error):
+class InsecureTransportError(OAuth2Error[TRequest]):
     """An exception will be thrown if the current request is not secure."""
 
     description = "OAuth 2 MUST utilize https."
     error = ErrorType.INSECURE_TRANSPORT
 
 
-class UnsupportedGrantTypeError(OAuth2Error):
+class UnsupportedGrantTypeError(OAuth2Error[TRequest]):
     """
     The authorization grant type is not supported by the authorization
     server.
@@ -101,7 +101,7 @@ class UnsupportedGrantTypeError(OAuth2Error):
     error = ErrorType.UNSUPPORTED_GRANT_TYPE
 
 
-class UnsupportedResponseTypeError(OAuth2Error):
+class UnsupportedResponseTypeError(OAuth2Error[TRequest]):
     """
     The authorization server does not support obtaining an authorization
     code using this method.
@@ -110,7 +110,7 @@ class UnsupportedResponseTypeError(OAuth2Error):
     error = ErrorType.UNSUPPORTED_RESPONSE_TYPE
 
 
-class InvalidGrantError(OAuth2Error):
+class InvalidGrantError(OAuth2Error[TRequest]):
     """
     The provided authorization grant (e.g. authorization code, resource
     owner credentials) or refresh token is invalid, expired, revoked, does
@@ -123,14 +123,14 @@ class InvalidGrantError(OAuth2Error):
     error = ErrorType.INVALID_GRANT
 
 
-class MismatchingStateError(OAuth2Error):
+class MismatchingStateError(OAuth2Error[TRequest]):
     """Unable to securely verify the integrity of the request and response."""
 
     description = "CSRF Warning! State not equal in request and response."
     error = ErrorType.MISMATCHING_STATE
 
 
-class UnauthorizedClientError(OAuth2Error):
+class UnauthorizedClientError(OAuth2Error[TRequest]):
     """
     The authenticated client is not authorized to use this authorization
     grant type.
@@ -139,7 +139,7 @@ class UnauthorizedClientError(OAuth2Error):
     error = ErrorType.UNAUTHORIZED_CLIENT
 
 
-class InvalidScopeError(OAuth2Error):
+class InvalidScopeError(OAuth2Error[TRequest]):
     """
     The requested scope is invalid, unknown, or malformed, or
     exceeds the scope granted by the resource owner.
@@ -150,7 +150,7 @@ class InvalidScopeError(OAuth2Error):
     error = ErrorType.INVALID_SCOPE
 
 
-class ServerError(OAuth2Error):
+class ServerError(OAuth2Error[TRequest]):
     """
     The authorization server encountered an unexpected condition that
     prevented it from fulfilling the request.  (This error code is needed
@@ -161,7 +161,7 @@ class ServerError(OAuth2Error):
     error = ErrorType.SERVER_ERROR
 
 
-class TemporarilyUnavailableError(OAuth2Error):
+class TemporarilyUnavailableError(OAuth2Error[TRequest]):
     """
     The authorization server is currently unable to handle the request
     due to a temporary overloading or maintenance of the server.

--- a/aioauth/grant_type.py
+++ b/aioauth/grant_type.py
@@ -58,15 +58,15 @@ class GrantTypeBase(Generic[TRequest]):
         )
 
         if not client:
-            raise InvalidRequestError(
+            raise InvalidRequestError[TRequest](
                 request=request, description="Invalid client_id parameter value."
             )
 
         if not client.check_grant_type(request.post.grant_type):
-            raise UnauthorizedClientError(request=request)
+            raise UnauthorizedClientError[TRequest](request=request)
 
         if not client.check_scope(request.post.scope):
-            raise InvalidScopeError(request=request)
+            raise InvalidScopeError[TRequest](request=request)
 
         return client
 
@@ -91,17 +91,17 @@ class AuthorizationCodeGrantType(GrantTypeBase[TRequest]):
         client = await super().validate_request(request)
 
         if not request.post.redirect_uri:
-            raise InvalidRequestError(
+            raise InvalidRequestError[TRequest](
                 request=request, description="Mismatching redirect URI."
             )
 
         if not client.check_redirect_uri(request.post.redirect_uri):
-            raise InvalidRequestError(
+            raise InvalidRequestError[TRequest](
                 request=request, description="Invalid redirect URI."
             )
 
         if not request.post.code:
-            raise InvalidRequestError(
+            raise InvalidRequestError[TRequest](
                 request=request, description="Missing code parameter."
             )
 
@@ -110,14 +110,14 @@ class AuthorizationCodeGrantType(GrantTypeBase[TRequest]):
         )
 
         if not authorization_code:
-            raise InvalidGrantError(request=request)
+            raise InvalidGrantError[TRequest](request=request)
 
         if (
             authorization_code.code_challenge
             and authorization_code.code_challenge_method
         ):
             if not request.post.code_verifier:
-                raise InvalidRequestError(
+                raise InvalidRequestError[TRequest](
                     request=request, description="Code verifier required."
                 )
 
@@ -125,10 +125,10 @@ class AuthorizationCodeGrantType(GrantTypeBase[TRequest]):
                 request.post.code_verifier
             )
             if not is_valid_code_challenge:
-                raise MismatchingStateError(request=request)
+                raise MismatchingStateError[TRequest](request=request)
 
         if authorization_code.is_expired:
-            raise InvalidGrantError(request=request)
+            raise InvalidGrantError[TRequest](request=request)
 
         return client
 
@@ -161,14 +161,14 @@ class PasswordGrantType(GrantTypeBase[TRequest]):
         client = await super().validate_request(request)
 
         if not request.post.username or not request.post.password:
-            raise InvalidRequestError(
+            raise InvalidRequestError[TRequest](
                 request=request, description="Invalid credentials given."
             )
 
         user = await self.storage.authenticate(request)
 
         if not user:
-            raise InvalidRequestError(
+            raise InvalidRequestError[TRequest](
                 request=request, description="Invalid credentials given."
             )
 
@@ -195,7 +195,7 @@ class RefreshTokenGrantType(GrantTypeBase[TRequest]):
         )
 
         if not old_token or old_token.revoked or old_token.refresh_token_expired:
-            raise InvalidGrantError(request=request)
+            raise InvalidGrantError[TRequest](request=request)
 
         # Revoke old token
         await self.storage.revoke_token(
@@ -231,7 +231,7 @@ class RefreshTokenGrantType(GrantTypeBase[TRequest]):
         client = await super().validate_request(request)
 
         if not request.post.refresh_token:
-            raise InvalidRequestError(
+            raise InvalidRequestError[TRequest](
                 request=request, description="Missing refresh token parameter."
             )
 

--- a/aioauth/grant_type.py
+++ b/aioauth/grant_type.py
@@ -15,7 +15,7 @@ from .errors import (
     UnauthorizedClientError,
 )
 from .models import Client
-from .requests import Request
+from .requests import BaseRequest
 from .responses import TokenResponse
 from .storage import BaseStorage
 from .utils import enforce_list, enforce_str, generate_token
@@ -30,7 +30,7 @@ class GrantTypeBase:
         self.client_secret = client_secret
 
     async def create_token_response(
-        self, request: Request, client: Client
+        self, request: BaseRequest, client: Client
     ) -> TokenResponse:
         """Creates token response to reply to client."""
         token = await self.storage.create_token(
@@ -50,7 +50,7 @@ class GrantTypeBase:
             token_type=token.token_type,
         )
 
-    async def validate_request(self, request: Request) -> Client:
+    async def validate_request(self, request: BaseRequest) -> Client:
         """Validates the client request to ensure it is valid."""
         client = await self.storage.get_client(
             request, client_id=self.client_id, client_secret=self.client_secret
@@ -86,7 +86,7 @@ class AuthorizationCodeGrantType(GrantTypeBase):
         See `RFC 6749 section 1.3.1 <https://tools.ietf.org/html/rfc6749#section-1.3.1>`_.
     """
 
-    async def validate_request(self, request: Request) -> Client:
+    async def validate_request(self, request: BaseRequest) -> Client:
         client = await super().validate_request(request)
 
         if not request.post.redirect_uri:
@@ -132,7 +132,7 @@ class AuthorizationCodeGrantType(GrantTypeBase):
         return client
 
     async def create_token_response(
-        self, request: Request, client: Client
+        self, request: BaseRequest, client: Client
     ) -> TokenResponse:
         token_response = await super().create_token_response(request, client)
 
@@ -156,7 +156,7 @@ class PasswordGrantType(GrantTypeBase):
     disallows the password grant entirely.
     """
 
-    async def validate_request(self, request: Request) -> Client:
+    async def validate_request(self, request: BaseRequest) -> Client:
         client = await super().validate_request(request)
 
         if not request.post.username or not request.post.password:
@@ -184,7 +184,7 @@ class RefreshTokenGrantType(GrantTypeBase):
     """
 
     async def create_token_response(
-        self, request: Request, client: Client
+        self, request: BaseRequest, client: Client
     ) -> TokenResponse:
         """Validate token request and create token response."""
         old_token = await self.storage.get_token(
@@ -226,7 +226,7 @@ class RefreshTokenGrantType(GrantTypeBase):
             token_type=token.token_type,
         )
 
-    async def validate_request(self, request: Request) -> Client:
+    async def validate_request(self, request: BaseRequest) -> Client:
         client = await super().validate_request(request)
 
         if not request.post.refresh_token:

--- a/aioauth/grant_type.py
+++ b/aioauth/grant_type.py
@@ -18,14 +18,14 @@ from .errors import (
 from .models import Client
 from .requests import TRequest
 from .responses import TokenResponse
-from .storage import BaseStorage
+from .storage import TStorage
 from .utils import enforce_list, enforce_str, generate_token
 
 
-class GrantTypeBase(Generic[TRequest]):
+class GrantTypeBase(Generic[TRequest, TStorage]):
     """Base grant type that all other grant types inherit from."""
 
-    def __init__(self, storage: BaseStorage, client_id: str, client_secret: str):
+    def __init__(self, storage: TStorage, client_id: str, client_secret: str):
         self.storage = storage
         self.client_id = client_id
         self.client_secret = client_secret
@@ -71,7 +71,7 @@ class GrantTypeBase(Generic[TRequest]):
         return client
 
 
-class AuthorizationCodeGrantType(GrantTypeBase[TRequest]):
+class AuthorizationCodeGrantType(GrantTypeBase[TRequest, TStorage]):
     """
     The Authorization Code grant type is used by confidential and public
     clients to exchange an authorization code for an access token. After
@@ -146,7 +146,7 @@ class AuthorizationCodeGrantType(GrantTypeBase[TRequest]):
         return token_response
 
 
-class PasswordGrantType(GrantTypeBase[TRequest]):
+class PasswordGrantType(GrantTypeBase[TRequest, TStorage]):
     """
     The Password grant type is a way to exchange a user's credentials
     for an access token. Because the client application has to collect
@@ -175,7 +175,7 @@ class PasswordGrantType(GrantTypeBase[TRequest]):
         return client
 
 
-class RefreshTokenGrantType(GrantTypeBase[TRequest]):
+class RefreshTokenGrantType(GrantTypeBase[TRequest, TStorage]):
     """
     The Refresh Token grant type is used by clients to exchange a
     refresh token for an access token when the access token has expired.
@@ -238,7 +238,7 @@ class RefreshTokenGrantType(GrantTypeBase[TRequest]):
         return client
 
 
-class ClientCredentialsGrantType(GrantTypeBase[TRequest]):
+class ClientCredentialsGrantType(GrantTypeBase[TRequest, TStorage]):
     """
     The Client Credentials grant type is used by clients to obtain an
     access token outside of the context of a user. This is typically

--- a/aioauth/models.py
+++ b/aioauth/models.py
@@ -9,7 +9,7 @@ Memory objects used throughout the project.
 """
 from dataclasses import dataclass
 import time
-from typing import Any, List, Optional, Union
+from typing import Any, List, Optional, TypeVar, Union
 
 from .types import CodeChallengeMethod, GrantType, ResponseType
 from .utils import create_s256_code_challenge, enforce_list, enforce_str
@@ -278,3 +278,8 @@ class Token:
     def refresh_token_expired(self) -> bool:
         """Checks if refresh token has expired."""
         return (self.issued_at + self.refresh_token_expires_in) < time.time()
+
+
+TToken = TypeVar("TToken", bound=Token)
+TClient = TypeVar("TClient", bound=Client)
+TAuthorizationCode = TypeVar("TAuthorizationCode", bound=AuthorizationCode)

--- a/aioauth/models.py
+++ b/aioauth/models.py
@@ -170,7 +170,7 @@ class AuthorizationCode:
     Authorization Server.
     """
 
-    code_challenge_method: Optional[str] = None
+    code_challenge_method: Optional[CodeChallengeMethod] = None
     """
     Only used when `RFC 7636 <tools.ietf.org/html/rfc7636>`_,
     Proof Key for Code Exchange, is used.
@@ -192,11 +192,11 @@ class AuthorizationCode:
     def check_code_challenge(self, code_verifier: str) -> bool:
         is_valid_code_challenge = False
 
-        if self.code_challenge_method == CodeChallengeMethod.PLAIN:
+        if self.code_challenge_method == "plain":
             # If the "code_challenge_method" was "plain", they are compared directly
             is_valid_code_challenge = code_verifier == self.code_challenge
 
-        if self.code_challenge_method == CodeChallengeMethod.S256:
+        if self.code_challenge_method == "S256":
             # base64url(sha256(ascii(code_verifier))) == code_challenge
             is_valid_code_challenge = (
                 create_s256_code_challenge(code_verifier) == self.code_challenge

--- a/aioauth/requests.py
+++ b/aioauth/requests.py
@@ -70,6 +70,9 @@ class BaseRequest(Generic[TQuery, TPost, TUser]):
     settings: Settings = Settings()
 
 
+TRequest = TypeVar("TRequest", bound=BaseRequest)
+
+
 @dataclass
 class Request(BaseRequest[Query, Post, Any]):
     """Object that contains a client's complete request."""

--- a/aioauth/requests.py
+++ b/aioauth/requests.py
@@ -8,7 +8,7 @@ Request objects used throughout the project.
 ----
 """
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any, Generic, Optional, TypeVar
 
 from .collections import HTTPHeaderDict
 from .config import Settings
@@ -54,14 +54,26 @@ class Post:
     code_verifier: Optional[str] = None
 
 
+TQuery = TypeVar("TQuery", bound=Query)
+TPost = TypeVar("TPost", bound=Post)
+TUser = TypeVar("TUser")
+
+
 @dataclass
-class Request:
+class BaseRequest(Generic[TQuery, TPost, TUser]):
+    method: RequestMethod
+    query: TQuery
+    post: TPost
+    headers: HTTPHeaderDict = HTTPHeaderDict()
+    url: str = ""
+    user: Optional[TUser] = None
+    settings: Settings = Settings()
+
+
+@dataclass
+class Request(BaseRequest[Query, Post, Any]):
     """Object that contains a client's complete request."""
 
-    method: RequestMethod
-    headers: HTTPHeaderDict = HTTPHeaderDict()
     query: Query = Query()
     post: Post = Post()
-    url: str = ""
     user: Optional[Any] = None
-    settings: Settings = Settings()

--- a/aioauth/response_type.py
+++ b/aioauth/response_type.py
@@ -38,7 +38,7 @@ class ResponseTypeBase(Generic[TRequest]):
         code_challenge_methods = list(CodeChallengeMethod)
 
         if not request.query.client_id:
-            raise InvalidRequestError(
+            raise InvalidRequestError[TRequest](
                 request=request, description="Missing client_id parameter."
             )
 
@@ -47,39 +47,39 @@ class ResponseTypeBase(Generic[TRequest]):
         )
 
         if not client:
-            raise InvalidRequestError(
+            raise InvalidRequestError[TRequest](
                 request=request, description="Invalid client_id parameter value."
             )
 
         if not request.query.redirect_uri:
-            raise InvalidRequestError(
+            raise InvalidRequestError[TRequest](
                 request=request, description="Mismatching redirect URI."
             )
 
         if not client.check_redirect_uri(request.query.redirect_uri):
-            raise InvalidRequestError(
+            raise InvalidRequestError[TRequest](
                 request=request, description="Invalid redirect URI."
             )
 
         if request.query.code_challenge_method:
             if request.query.code_challenge_method not in code_challenge_methods:
-                raise InvalidRequestError(
+                raise InvalidRequestError[TRequest](
                     request=request, description="Transform algorithm not supported."
                 )
 
             if not request.query.code_challenge:
-                raise InvalidRequestError(
+                raise InvalidRequestError[TRequest](
                     request=request, description="Code challenge required."
                 )
 
         if not client.check_response_type(request.query.response_type):
-            raise UnsupportedResponseTypeError(request=request)
+            raise UnsupportedResponseTypeError[TRequest](request=request)
 
         if not client.check_scope(request.query.scope):
-            raise InvalidScopeError(request=request)
+            raise InvalidScopeError[TRequest](request=request)
 
         if not request.user:
-            raise InvalidClientError(
+            raise InvalidClientError[TRequest](
                 request=request, description="User is not authorized"
             )
 
@@ -137,7 +137,7 @@ class ResponseTypeIdToken(ResponseTypeBase[TRequest]):
 
         # nonce is required for id_token
         if not request.query.nonce:
-            raise InvalidRequestError(
+            raise InvalidRequestError[TRequest](
                 request=request,
                 description="Nonce required for response_type id_token.",
             )

--- a/aioauth/response_type.py
+++ b/aioauth/response_type.py
@@ -8,7 +8,7 @@ Response objects used throughout the project.
 ----
 """
 
-from typing import Generic
+from typing import Generic, List
 from .utils import generate_token
 from .errors import (
     InvalidClientError,
@@ -35,7 +35,7 @@ class ResponseTypeBase(Generic[TRequest, TStorage]):
         self.storage = storage
 
     async def validate_request(self, request: TRequest) -> Client:
-        code_challenge_methods = list(CodeChallengeMethod)
+        code_challenge_methods: List[CodeChallengeMethod] = ["plain", "S256"]
 
         if not request.query.client_id:
             raise InvalidRequestError[TRequest](

--- a/aioauth/response_type.py
+++ b/aioauth/response_type.py
@@ -16,7 +16,7 @@ from .errors import (
     UnsupportedResponseTypeError,
 )
 from .models import Client
-from .requests import Request
+from .requests import BaseRequest
 from .responses import (
     AuthorizationCodeResponse,
     IdTokenResponse,
@@ -33,7 +33,7 @@ class ResponseTypeBase:
     def __init__(self, storage: BaseStorage):
         self.storage = storage
 
-    async def validate_request(self, request: Request) -> Client:
+    async def validate_request(self, request: BaseRequest) -> Client:
         code_challenge_methods = list(CodeChallengeMethod)
 
         if not request.query.client_id:
@@ -89,7 +89,7 @@ class ResponseTypeToken(ResponseTypeBase):
     """Response type that contains a token."""
 
     async def create_authorization_response(
-        self, request: Request, client: Client
+        self, request: BaseRequest, client: Client
     ) -> TokenResponse:
         token = await self.storage.create_token(
             request,
@@ -112,7 +112,7 @@ class ResponseTypeAuthorizationCode(ResponseTypeBase):
     """Response type that contains an authorization code."""
 
     async def create_authorization_response(
-        self, request: Request, client: Client
+        self, request: BaseRequest, client: Client
     ) -> AuthorizationCodeResponse:
         authorization_code = await self.storage.create_authorization_code(
             request,
@@ -131,7 +131,7 @@ class ResponseTypeAuthorizationCode(ResponseTypeBase):
 
 
 class ResponseTypeIdToken(ResponseTypeBase):
-    async def validate_request(self, request: Request) -> Client:
+    async def validate_request(self, request: BaseRequest) -> Client:
         client = await super().validate_request(request)
 
         # nonce is required for id_token
@@ -143,7 +143,7 @@ class ResponseTypeIdToken(ResponseTypeBase):
         return client
 
     async def create_authorization_response(
-        self, request: Request, client: Client
+        self, request: BaseRequest, client: Client
     ) -> IdTokenResponse:
         id_token = await self.storage.get_id_token(
             request,
@@ -159,6 +159,6 @@ class ResponseTypeIdToken(ResponseTypeBase):
 
 class ResponseTypeNone(ResponseTypeBase):
     async def create_authorization_response(
-        self, request: Request, client: Client
+        self, request: BaseRequest, client: Client
     ) -> NoneResponse:
         return NoneResponse()

--- a/aioauth/response_type.py
+++ b/aioauth/response_type.py
@@ -24,14 +24,14 @@ from .responses import (
     NoneResponse,
     TokenResponse,
 )
-from .storage import BaseStorage
+from .storage import TStorage
 from .types import CodeChallengeMethod
 
 
-class ResponseTypeBase(Generic[TRequest]):
+class ResponseTypeBase(Generic[TRequest, TStorage]):
     """Base response type that all other exceptions inherit from."""
 
-    def __init__(self, storage: BaseStorage):
+    def __init__(self, storage: TStorage):
         self.storage = storage
 
     async def validate_request(self, request: TRequest) -> Client:
@@ -86,7 +86,7 @@ class ResponseTypeBase(Generic[TRequest]):
         return client
 
 
-class ResponseTypeToken(ResponseTypeBase[TRequest]):
+class ResponseTypeToken(ResponseTypeBase[TRequest, TStorage]):
     """Response type that contains a token."""
 
     async def create_authorization_response(
@@ -109,7 +109,7 @@ class ResponseTypeToken(ResponseTypeBase[TRequest]):
         )
 
 
-class ResponseTypeAuthorizationCode(ResponseTypeBase[TRequest]):
+class ResponseTypeAuthorizationCode(ResponseTypeBase[TRequest, TStorage]):
     """Response type that contains an authorization code."""
 
     async def create_authorization_response(
@@ -131,7 +131,7 @@ class ResponseTypeAuthorizationCode(ResponseTypeBase[TRequest]):
         )
 
 
-class ResponseTypeIdToken(ResponseTypeBase[TRequest]):
+class ResponseTypeIdToken(ResponseTypeBase[TRequest, TStorage]):
     async def validate_request(self, request: TRequest) -> Client:
         client = await super().validate_request(request)
 
@@ -158,7 +158,7 @@ class ResponseTypeIdToken(ResponseTypeBase[TRequest]):
         return IdTokenResponse(id_token=id_token)
 
 
-class ResponseTypeNone(ResponseTypeBase[TRequest]):
+class ResponseTypeNone(ResponseTypeBase[TRequest, TStorage]):
     async def create_authorization_response(
         self, request: TRequest, client: Client
     ) -> NoneResponse:

--- a/aioauth/server.py
+++ b/aioauth/server.py
@@ -264,11 +264,11 @@ class AuthorizationServer(Generic[TRequest]):
 
         GrantTypeClass: Type[
             Union[
-                GrantTypeBase,
-                AuthorizationCodeGrantType,
-                PasswordGrantType,
-                RefreshTokenGrantType,
-                ClientCredentialsGrantType,
+                GrantTypeBase[TRequest],
+                AuthorizationCodeGrantType[TRequest],
+                PasswordGrantType[TRequest],
+                RefreshTokenGrantType[TRequest],
+                ClientCredentialsGrantType[TRequest],
             ]
         ]
 

--- a/aioauth/server.py
+++ b/aioauth/server.py
@@ -50,7 +50,7 @@ from .responses import (
     TokenActiveIntrospectionResponse,
     TokenInactiveIntrospectionResponse,
 )
-from .storage import BaseStorage
+from .storage import TStorage
 from .types import (
     GrantType,
     RequestMethod,
@@ -66,25 +66,29 @@ from .utils import (
 )
 
 
-class AuthorizationServer(Generic[TRequest]):
+class AuthorizationServer(Generic[TRequest, TStorage]):
     """Interface for initializing an OAuth 2.0 server."""
 
     response_types = {
-        ResponseType.TYPE_TOKEN: ResponseTypeToken[TRequest],
-        ResponseType.TYPE_CODE: ResponseTypeAuthorizationCode[TRequest],
-        ResponseType.TYPE_NONE: ResponseTypeNone[TRequest],
-        ResponseType.TYPE_ID_TOKEN: ResponseTypeIdToken[TRequest],
+        ResponseType.TYPE_TOKEN: ResponseTypeToken[TRequest, TStorage],
+        ResponseType.TYPE_CODE: ResponseTypeAuthorizationCode[TRequest, TStorage],
+        ResponseType.TYPE_NONE: ResponseTypeNone[TRequest, TStorage],
+        ResponseType.TYPE_ID_TOKEN: ResponseTypeIdToken[TRequest, TStorage],
     }
     grant_types = {
-        GrantType.TYPE_AUTHORIZATION_CODE: AuthorizationCodeGrantType[TRequest],
-        GrantType.TYPE_CLIENT_CREDENTIALS: ClientCredentialsGrantType[TRequest],
-        GrantType.TYPE_PASSWORD: PasswordGrantType[TRequest],
-        GrantType.TYPE_REFRESH_TOKEN: RefreshTokenGrantType[TRequest],
+        GrantType.TYPE_AUTHORIZATION_CODE: AuthorizationCodeGrantType[
+            TRequest, TStorage
+        ],
+        GrantType.TYPE_CLIENT_CREDENTIALS: ClientCredentialsGrantType[
+            TRequest, TStorage
+        ],
+        GrantType.TYPE_PASSWORD: PasswordGrantType[TRequest, TStorage],
+        GrantType.TYPE_REFRESH_TOKEN: RefreshTokenGrantType[TRequest, TStorage],
     }
 
     def __init__(
         self,
-        storage: BaseStorage,
+        storage: TStorage,
         response_types: Optional[Dict] = None,
         grant_types: Optional[Dict] = None,
     ):
@@ -264,11 +268,11 @@ class AuthorizationServer(Generic[TRequest]):
 
         GrantTypeClass: Type[
             Union[
-                GrantTypeBase[TRequest],
-                AuthorizationCodeGrantType[TRequest],
-                PasswordGrantType[TRequest],
-                RefreshTokenGrantType[TRequest],
-                ClientCredentialsGrantType[TRequest],
+                GrantTypeBase[TRequest, TStorage],
+                AuthorizationCodeGrantType[TRequest, TStorage],
+                PasswordGrantType[TRequest, TStorage],
+                RefreshTokenGrantType[TRequest, TStorage],
+                ClientCredentialsGrantType[TRequest, TStorage],
             ]
         ]
 

--- a/aioauth/server.py
+++ b/aioauth/server.py
@@ -38,7 +38,7 @@ from .grant_type import (
     PasswordGrantType,
     RefreshTokenGrantType,
 )
-from .requests import Request
+from .requests import BaseRequest
 from .response_type import (
     ResponseTypeAuthorizationCode,
     ResponseTypeIdToken,
@@ -96,7 +96,7 @@ class AuthorizationServer:
         if grant_types is not None:
             self.grant_types = grant_types
 
-    def is_secure_transport(self, request: Request) -> bool:
+    def is_secure_transport(self, request: BaseRequest) -> bool:
         """
         Verifies the request was sent via a protected SSL tunnel.
 
@@ -113,7 +113,9 @@ class AuthorizationServer:
             return True
         return request.url.lower().startswith("https://")
 
-    def validate_request(self, request: Request, allowed_methods: List[RequestMethod]):
+    def validate_request(
+        self, request: BaseRequest, allowed_methods: List[RequestMethod]
+    ):
         if not request.settings.AVAILABLE:
             raise TemporarilyUnavailableError(request=request)
 
@@ -127,7 +129,9 @@ class AuthorizationServer:
             raise MethodNotAllowedError(request=request, headers=headers)
 
     @catch_errors_and_unavailability
-    async def create_token_introspection_response(self, request: Request) -> Response:
+    async def create_token_introspection_response(
+        self, request: BaseRequest
+    ) -> Response:
         """
         Returns a response object with introspection of the passed token.
         For more information see `RFC7662 section 2.1 <https://tools.ietf.org/html/rfc7662#section-2.1>`_.
@@ -202,7 +206,7 @@ class AuthorizationServer:
             content=content, status_code=HTTPStatus.OK, headers=default_headers
         )
 
-    def get_client_credentials(self, request: Request) -> Tuple[str, str]:
+    def get_client_credentials(self, request: BaseRequest) -> Tuple[str, str]:
         client_id = request.post.client_id
         client_secret = request.post.client_secret
 
@@ -219,7 +223,7 @@ class AuthorizationServer:
         return client_id, client_secret
 
     @catch_errors_and_unavailability
-    async def create_token_response(self, request: Request) -> Response:
+    async def create_token_response(self, request: BaseRequest) -> Response:
         """Endpoint to obtain an access and/or ID token by presenting an
         authorization grant or refresh token.
         Validates a token request and creates a token response.
@@ -290,7 +294,7 @@ class AuthorizationServer:
         )
 
     @catch_errors_and_unavailability
-    async def create_authorization_response(self, request: Request) -> Response:
+    async def create_authorization_response(self, request: BaseRequest) -> Response:
         """
         Endpoint to interact with the resource owner and obtain an
         authorization grant.

--- a/aioauth/storage.py
+++ b/aioauth/storage.py
@@ -10,16 +10,11 @@ action.
 ----
 """
 
-from typing import Optional, TypeVar, Generic
+from typing import Optional, Generic
 from aioauth.types import TokenType
 
-from .models import AuthorizationCode, Client, Token
+from .models import TToken, TClient, TAuthorizationCode
 from .requests import TRequest
-
-
-TToken = TypeVar("TToken", bound=Token)
-TClient = TypeVar("TClient", bound=Client)
-TAuthorizationCode = TypeVar("TAuthorizationCode", bound=AuthorizationCode)
 
 
 class BaseStorage(Generic[TToken, TClient, TAuthorizationCode, TRequest]):

--- a/aioauth/storage.py
+++ b/aioauth/storage.py
@@ -11,7 +11,7 @@ action.
 """
 
 from typing import Optional, Generic, TypeVar
-from .types import TokenType
+from .types import CodeChallengeMethod, ResponseType, TokenType
 
 from .models import TToken, TClient, TAuthorizationCode
 from .requests import TRequest
@@ -46,7 +46,7 @@ class BaseStorage(Generic[TToken, TClient, TAuthorizationCode, TRequest]):
         self,
         request: TRequest,
         client_id: str,
-        token_type: Optional[str] = TokenType.REFRESH,
+        token_type: Optional[TokenType] = "refresh_token",
         access_token: Optional[str] = None,
         refresh_token: Optional[str] = None,
     ) -> Optional[TToken]:
@@ -71,9 +71,9 @@ class BaseStorage(Generic[TToken, TClient, TAuthorizationCode, TRequest]):
         request: TRequest,
         client_id: str,
         scope: str,
-        response_type: str,
+        response_type: ResponseType,
         redirect_uri: str,
-        code_challenge_method: Optional[str],
+        code_challenge_method: Optional[CodeChallengeMethod],
         code_challenge: Optional[str],
         code: str,
     ) -> TAuthorizationCode:
@@ -104,7 +104,7 @@ class BaseStorage(Generic[TToken, TClient, TAuthorizationCode, TRequest]):
         request: TRequest,
         client_id: str,
         scope: str,
-        response_type: str,
+        response_type: ResponseType,
         redirect_uri: str,
         nonce: str,
     ) -> str:

--- a/aioauth/storage.py
+++ b/aioauth/storage.py
@@ -14,7 +14,7 @@ from typing import Optional, TypeVar, Generic
 from aioauth.types import TokenType
 
 from .models import AuthorizationCode, Client, Token
-from .requests import BaseRequest
+from .requests import TRequest
 
 
 TToken = TypeVar("TToken", bound=Token)
@@ -22,10 +22,10 @@ TClient = TypeVar("TClient", bound=Client)
 TAuthorizationCode = TypeVar("TAuthorizationCode", bound=AuthorizationCode)
 
 
-class BaseStorage(Generic[TToken, TClient, TAuthorizationCode]):
+class BaseStorage(Generic[TToken, TClient, TAuthorizationCode, TRequest]):
     async def create_token(
         self,
-        request: BaseRequest,
+        request: TRequest,
         client_id: str,
         scope: str,
         access_token: str,
@@ -49,7 +49,7 @@ class BaseStorage(Generic[TToken, TClient, TAuthorizationCode]):
 
     async def get_token(
         self,
-        request: BaseRequest,
+        request: TRequest,
         client_id: str,
         token_type: Optional[str] = TokenType.REFRESH,
         access_token: Optional[str] = None,
@@ -73,7 +73,7 @@ class BaseStorage(Generic[TToken, TClient, TAuthorizationCode]):
 
     async def create_authorization_code(
         self,
-        request: BaseRequest,
+        request: TRequest,
         client_id: str,
         scope: str,
         response_type: str,
@@ -106,7 +106,7 @@ class BaseStorage(Generic[TToken, TClient, TAuthorizationCode]):
 
     async def get_id_token(
         self,
-        request: BaseRequest,
+        request: TRequest,
         client_id: str,
         scope: str,
         response_type: str,
@@ -122,7 +122,7 @@ class BaseStorage(Generic[TToken, TClient, TAuthorizationCode]):
         raise NotImplementedError("get_id_token must be implemented.")
 
     async def get_client(
-        self, request: BaseRequest, client_id: str, client_secret: Optional[str] = None
+        self, request: TRequest, client_id: str, client_secret: Optional[str] = None
     ) -> Optional[TClient]:
         """Gets existing client from the database if it exists.
 
@@ -142,7 +142,7 @@ class BaseStorage(Generic[TToken, TClient, TAuthorizationCode]):
         """
         raise NotImplementedError("Method get_client must be implemented")
 
-    async def authenticate(self, request: BaseRequest) -> bool:
+    async def authenticate(self, request: TRequest) -> bool:
         """Authenticates a user.
 
         Note:
@@ -157,7 +157,7 @@ class BaseStorage(Generic[TToken, TClient, TAuthorizationCode]):
         raise NotImplementedError("Method authenticate must be implemented")
 
     async def get_authorization_code(
-        self, request: BaseRequest, client_id: str, code: str
+        self, request: TRequest, client_id: str, code: str
     ) -> Optional[TAuthorizationCode]:
         """Gets existing authorization code from the database if it exists.
 
@@ -180,7 +180,7 @@ class BaseStorage(Generic[TToken, TClient, TAuthorizationCode]):
         )
 
     async def delete_authorization_code(
-        self, request: BaseRequest, client_id: str, code: str
+        self, request: TRequest, client_id: str, code: str
     ) -> None:
         """Deletes authorization code from database.
 
@@ -196,7 +196,7 @@ class BaseStorage(Generic[TToken, TClient, TAuthorizationCode]):
             "Method delete_authorization_code must be implemented for AuthorizationCodeGrantType"
         )
 
-    async def revoke_token(self, request: BaseRequest, refresh_token: str) -> None:
+    async def revoke_token(self, request: TRequest, refresh_token: str) -> None:
         """Revokes a token's from the database.
 
         Note:

--- a/aioauth/storage.py
+++ b/aioauth/storage.py
@@ -11,7 +11,7 @@ action.
 """
 
 from typing import Optional, Generic
-from aioauth.types import TokenType
+from .types import TokenType
 
 from .models import TToken, TClient, TAuthorizationCode
 from .requests import TRequest

--- a/aioauth/storage.py
+++ b/aioauth/storage.py
@@ -10,24 +10,28 @@ action.
 ----
 """
 
-import time
-from typing import Optional
-
+from typing import Optional, TypeVar, Generic
 from aioauth.types import TokenType
 
 from .models import AuthorizationCode, Client, Token
 from .requests import Request
 
 
-class BaseStorage:
+TToken = TypeVar("TToken", bound=Token)
+TClient = TypeVar("TClient", bound=Client)
+TAuthorizationCode = TypeVar("TAuthorizationCode", bound=AuthorizationCode)
+TRequest = TypeVar("TRequest", bound=Request)
+
+
+class BaseStorage(Generic[TToken, TClient, TAuthorizationCode, TRequest]):
     async def create_token(
         self,
-        request: Request,
+        request: TRequest,
         client_id: str,
         scope: str,
         access_token: str,
         refresh_token: str,
-    ) -> Token:
+    ) -> TToken:
         """Generates a user token and stores it in the database.
 
         Warning:
@@ -42,26 +46,16 @@ class BaseStorage:
         Returns:
             The new generated :py:class:`aioauth.models.Token`.
         """
-        token = Token(
-            client_id=client_id,
-            expires_in=request.settings.TOKEN_EXPIRES_IN,
-            refresh_token_expires_in=request.settings.REFRESH_TOKEN_EXPIRES_IN,
-            access_token=access_token,
-            refresh_token=refresh_token,
-            issued_at=int(time.time()),
-            scope=scope,
-            revoked=False,
-        )
-        return token
+        raise NotImplementedError("Method create_token must be implemented")
 
     async def get_token(
         self,
-        request: Request,
+        request: TRequest,
         client_id: str,
         token_type: Optional[str] = TokenType.REFRESH,
         access_token: Optional[str] = None,
         refresh_token: Optional[str] = None,
-    ) -> Optional[Token]:
+    ) -> Optional[TToken]:
         """Gets existing token from the database.
 
         Note:
@@ -80,7 +74,7 @@ class BaseStorage:
 
     async def create_authorization_code(
         self,
-        request: Request,
+        request: TRequest,
         client_id: str,
         scope: str,
         response_type: str,
@@ -88,7 +82,7 @@ class BaseStorage:
         code_challenge_method: Optional[str],
         code_challenge: Optional[str],
         code: str,
-    ) -> AuthorizationCode:
+    ) -> TAuthorizationCode:
         """Generates an authorization token and stores it in the database.
 
         Warning:
@@ -107,22 +101,13 @@ class BaseStorage:
         Returns:
             An :py:class:`aioauth.models.AuthorizationCode` object.
         """
-        authorization_code = AuthorizationCode(
-            code=code,
-            client_id=client_id,
-            redirect_uri=redirect_uri,
-            response_type=response_type,
-            scope=scope,
-            auth_time=int(time.time()),
-            code_challenge_method=code_challenge_method,
-            code_challenge=code_challenge,
-            expires_in=request.settings.AUTHORIZATION_CODE_EXPIRES_IN,
+        raise NotImplementedError(
+            "Method create_authorization_code must be implemented"
         )
-        return authorization_code
 
     async def get_id_token(
         self,
-        request: Request,
+        request: TRequest,
         client_id: str,
         scope: str,
         response_type: str,
@@ -138,8 +123,8 @@ class BaseStorage:
         raise NotImplementedError("get_id_token must be implemented.")
 
     async def get_client(
-        self, request: Request, client_id: str, client_secret: Optional[str] = None
-    ) -> Optional[Client]:
+        self, request: TRequest, client_id: str, client_secret: Optional[str] = None
+    ) -> Optional[TClient]:
         """Gets existing client from the database if it exists.
 
         Warning:
@@ -158,7 +143,7 @@ class BaseStorage:
         """
         raise NotImplementedError("Method get_client must be implemented")
 
-    async def authenticate(self, request: Request) -> bool:
+    async def authenticate(self, request: TRequest) -> bool:
         """Authenticates a user.
 
         Note:
@@ -173,8 +158,8 @@ class BaseStorage:
         raise NotImplementedError("Method authenticate must be implemented")
 
     async def get_authorization_code(
-        self, request: Request, client_id: str, code: str
-    ) -> Optional[AuthorizationCode]:
+        self, request: TRequest, client_id: str, code: str
+    ) -> Optional[TAuthorizationCode]:
         """Gets existing authorization code from the database if it exists.
 
         Warning:
@@ -196,7 +181,7 @@ class BaseStorage:
         )
 
     async def delete_authorization_code(
-        self, request: Request, client_id: str, code: str
+        self, request: TRequest, client_id: str, code: str
     ) -> None:
         """Deletes authorization code from database.
 
@@ -212,7 +197,7 @@ class BaseStorage:
             "Method delete_authorization_code must be implemented for AuthorizationCodeGrantType"
         )
 
-    async def revoke_token(self, request: Request, refresh_token: str) -> None:
+    async def revoke_token(self, request: TRequest, refresh_token: str) -> None:
         """Revokes a token's from the database.
 
         Note:

--- a/aioauth/storage.py
+++ b/aioauth/storage.py
@@ -14,19 +14,18 @@ from typing import Optional, TypeVar, Generic
 from aioauth.types import TokenType
 
 from .models import AuthorizationCode, Client, Token
-from .requests import Request
+from .requests import BaseRequest
 
 
 TToken = TypeVar("TToken", bound=Token)
 TClient = TypeVar("TClient", bound=Client)
 TAuthorizationCode = TypeVar("TAuthorizationCode", bound=AuthorizationCode)
-TRequest = TypeVar("TRequest", bound=Request)
 
 
-class BaseStorage(Generic[TToken, TClient, TAuthorizationCode, TRequest]):
+class BaseStorage(Generic[TToken, TClient, TAuthorizationCode]):
     async def create_token(
         self,
-        request: TRequest,
+        request: BaseRequest,
         client_id: str,
         scope: str,
         access_token: str,
@@ -50,7 +49,7 @@ class BaseStorage(Generic[TToken, TClient, TAuthorizationCode, TRequest]):
 
     async def get_token(
         self,
-        request: TRequest,
+        request: BaseRequest,
         client_id: str,
         token_type: Optional[str] = TokenType.REFRESH,
         access_token: Optional[str] = None,
@@ -74,7 +73,7 @@ class BaseStorage(Generic[TToken, TClient, TAuthorizationCode, TRequest]):
 
     async def create_authorization_code(
         self,
-        request: TRequest,
+        request: BaseRequest,
         client_id: str,
         scope: str,
         response_type: str,
@@ -107,7 +106,7 @@ class BaseStorage(Generic[TToken, TClient, TAuthorizationCode, TRequest]):
 
     async def get_id_token(
         self,
-        request: TRequest,
+        request: BaseRequest,
         client_id: str,
         scope: str,
         response_type: str,
@@ -123,7 +122,7 @@ class BaseStorage(Generic[TToken, TClient, TAuthorizationCode, TRequest]):
         raise NotImplementedError("get_id_token must be implemented.")
 
     async def get_client(
-        self, request: TRequest, client_id: str, client_secret: Optional[str] = None
+        self, request: BaseRequest, client_id: str, client_secret: Optional[str] = None
     ) -> Optional[TClient]:
         """Gets existing client from the database if it exists.
 
@@ -143,7 +142,7 @@ class BaseStorage(Generic[TToken, TClient, TAuthorizationCode, TRequest]):
         """
         raise NotImplementedError("Method get_client must be implemented")
 
-    async def authenticate(self, request: TRequest) -> bool:
+    async def authenticate(self, request: BaseRequest) -> bool:
         """Authenticates a user.
 
         Note:
@@ -158,7 +157,7 @@ class BaseStorage(Generic[TToken, TClient, TAuthorizationCode, TRequest]):
         raise NotImplementedError("Method authenticate must be implemented")
 
     async def get_authorization_code(
-        self, request: TRequest, client_id: str, code: str
+        self, request: BaseRequest, client_id: str, code: str
     ) -> Optional[TAuthorizationCode]:
         """Gets existing authorization code from the database if it exists.
 
@@ -181,7 +180,7 @@ class BaseStorage(Generic[TToken, TClient, TAuthorizationCode, TRequest]):
         )
 
     async def delete_authorization_code(
-        self, request: TRequest, client_id: str, code: str
+        self, request: BaseRequest, client_id: str, code: str
     ) -> None:
         """Deletes authorization code from database.
 
@@ -197,7 +196,7 @@ class BaseStorage(Generic[TToken, TClient, TAuthorizationCode, TRequest]):
             "Method delete_authorization_code must be implemented for AuthorizationCodeGrantType"
         )
 
-    async def revoke_token(self, request: TRequest, refresh_token: str) -> None:
+    async def revoke_token(self, request: BaseRequest, refresh_token: str) -> None:
         """Revokes a token's from the database.
 
         Note:

--- a/aioauth/storage.py
+++ b/aioauth/storage.py
@@ -10,7 +10,7 @@ action.
 ----
 """
 
-from typing import Optional, Generic
+from typing import Optional, Generic, TypeVar
 from .types import TokenType
 
 from .models import TToken, TClient, TAuthorizationCode
@@ -205,3 +205,6 @@ class BaseStorage(Generic[TToken, TClient, TAuthorizationCode, TRequest]):
         raise NotImplementedError(
             "Method revoke_token must be implemented for RefreshTokenGrantType"
         )
+
+
+TStorage = TypeVar("TStorage", bound=BaseStorage)

--- a/aioauth/types.py
+++ b/aioauth/types.py
@@ -7,67 +7,55 @@ Containers that contain constants used throughout the project.
 
 ----
 """
-
-from enum import Enum
-
-
-class ErrorType(str, Enum):
-    """Error types."""
-
-    INVALID_REQUEST = "invalid_request"
-    INVALID_CLIENT = "invalid_client"
-    INVALID_GRANT = "invalid_grant"
-    INVALID_SCOPE = "invalid_scope"
-    UNAUTHORIZED_CLIENT = "unauthorized_client"
-    UNSUPPORTED_GRANT_TYPE = "unsupported_grant_type"
-    UNSUPPORTED_RESPONSE_TYPE = "unsupported_response_type"
-    INSECURE_TRANSPORT = "insecure_transport"
-    MISMATCHING_STATE = "mismatching_state"
-    METHOD_IS_NOT_ALLOWED = "method_is_not_allowed"
-    SERVER_ERROR = "server_error"
-    TEMPORARILY_UNAVAILABLE = "temporarily_unavailable"
+from typing_extensions import Literal
 
 
-class GrantType(str, Enum):
-    """Grant types."""
-
-    TYPE_AUTHORIZATION_CODE = "authorization_code"
-    TYPE_PASSWORD = "password"
-    TYPE_CLIENT_CREDENTIALS = "client_credentials"
-    TYPE_REFRESH_TOKEN = "refresh_token"
-
-
-class ResponseType(str, Enum):
-    """Response types."""
-
-    TYPE_TOKEN = "token"
-    TYPE_CODE = "code"
-    TYPE_NONE = "none"
-    TYPE_ID_TOKEN = "id_token"
+ErrorType = Literal[
+    "invalid_request",
+    "invalid_client",
+    "invalid_grant",
+    "invalid_scope",
+    "unauthorized_client",
+    "unsupported_grant_type",
+    "unsupported_response_type",
+    "insecure_transport",
+    "mismatching_state",
+    "method_is_not_allowed",
+    "server_error",
+    "temporarily_unavailable",
+]
 
 
-class RequestMethod(str, Enum):
-    """Request types."""
-
-    GET = "GET"
-    POST = "POST"
-
-
-class CodeChallengeMethod(str, Enum):
-    """Code challenge types."""
-
-    PLAIN = "plain"
-    S256 = "S256"
+GrantType = Literal[
+    "authorization_code",
+    "password",
+    "client_credentials",
+    "refresh_token",
+]
 
 
-class ResponseMode(str, Enum):
-    """Response modes."""
+ResponseType = Literal[
+    "token",
+    "code",
+    "none",
+    "id_token",
+]
 
-    MODE_QUERY = "query"
-    MODE_FORM_POST = "form_post"
-    MODE_FRAGMENT = "fragment"
+
+RequestMethod = Literal["GET", "POST"]
 
 
-class TokenType(str, Enum):
-    ACCESS = "access_token"
-    REFRESH = "refresh_token"
+CodeChallengeMethod = Literal[
+    "plain",
+    "S256",
+]
+
+
+ResponseMode = Literal[
+    "query",
+    "form_post",
+    "fragment",
+]
+
+
+TokenType = Literal["access_token", "refresh_token"]

--- a/aioauth/utils.py
+++ b/aioauth/utils.py
@@ -28,7 +28,6 @@ from .errors import (
     ServerError,
     TemporarilyUnavailableError,
 )
-from .requests import BaseRequest
 from .responses import ErrorResponse, Response
 
 UNICODE_ASCII_CHARACTER_SET = string.ascii_letters + string.digits
@@ -225,7 +224,7 @@ def catch_errors_and_unavailability(f) -> Callable[..., Coroutine[Any, Any, Resp
     """
 
     @functools.wraps(f)
-    async def wrapper(self, request: BaseRequest, *args, **kwargs) -> Response:
+    async def wrapper(self, request, *args, **kwargs) -> Response:
         error: Union[TemporarilyUnavailableError, ServerError]
 
         try:

--- a/aioauth/utils.py
+++ b/aioauth/utils.py
@@ -28,7 +28,7 @@ from .errors import (
     ServerError,
     TemporarilyUnavailableError,
 )
-from .requests import Request
+from .requests import BaseRequest
 from .responses import ErrorResponse, Response
 
 UNICODE_ASCII_CHARACTER_SET = string.ascii_letters + string.digits
@@ -225,7 +225,7 @@ def catch_errors_and_unavailability(f) -> Callable[..., Coroutine[Any, Any, Resp
     """
 
     @functools.wraps(f)
-    async def wrapper(self, request: Request, *args, **kwargs) -> Response:
+    async def wrapper(self, request: BaseRequest, *args, **kwargs) -> Response:
         error: Union[TemporarilyUnavailableError, ServerError]
 
         try:

--- a/docs/source/sections/examples/fastapi.rst
+++ b/docs/source/sections/examples/fastapi.rst
@@ -16,19 +16,20 @@ Usage example
 
     from aioauth_fastapi.router import get_oauth2_router
     from aioauth.storage import BaseStorage
+    from aioauth.models import AuthorizationCode, Client, Token
     from aioauth.config import Settings
     from aioauth.server import AuthorizationServer
     from fastapi import FastAPI
 
     app = FastAPI()
 
-    class Storage(BaseStorage):
+    class Storage(BaseStorage[Token, Client, AuthorizationCode, Request]):
         """
         Storage methods must be implemented here.
         """
 
     storage = Storage()
-    authorization_server = AuthorizationServer(storage)
+    authorization_server = AuthorizationServer[Request, Storage](storage)
 
     # NOTE: Redefinition of the default aioauth settings
     # INSECURE_TRANSPORT must be enabled for local development only!

--- a/docs/source/sections/examples/fastapi.rst
+++ b/docs/source/sections/examples/fastapi.rst
@@ -16,6 +16,7 @@ Usage example
 
     from aioauth_fastapi.router import get_oauth2_router
     from aioauth.storage import BaseStorage
+    from aioauth.requests import Request
     from aioauth.models import AuthorizationCode, Client, Token
     from aioauth.config import Settings
     from aioauth.server import AuthorizationServer

--- a/docs/source/sections/examples/fastapi.rst
+++ b/docs/source/sections/examples/fastapi.rst
@@ -14,15 +14,27 @@ Usage example
 
 .. code-block:: python
 
+    from dataclasses import dataclasses
     from aioauth_fastapi.router import get_oauth2_router
     from aioauth.storage import BaseStorage
-    from aioauth.requests import Request
+    from aioauth.requests import BaseRequest, Query, Post
     from aioauth.models import AuthorizationCode, Client, Token
     from aioauth.config import Settings
     from aioauth.server import AuthorizationServer
     from fastapi import FastAPI
 
     app = FastAPI()
+
+    @dataclasses
+    class User:
+        """Custom user model"""
+        first_name: str
+        last_name: str
+
+
+    class Request(BaseRequest[Query, Post, User]):
+        """Custom Request model"""
+
 
     class Storage(BaseStorage[Token, Client, AuthorizationCode, Request]):
         """

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,7 @@ setup(
     package_data={"aioauth": ["py.typed"]},
     python_requires=">=3.7.0",
     classifiers=classifiers,
+    install_requires=["typing_extensions"],
     extras_require={
         "fastapi": ["aioauth-fastapi>=0.0.1"],
         "dev": require_dev,

--- a/tests/classes.py
+++ b/tests/classes.py
@@ -1,16 +1,17 @@
+import time
+
 from dataclasses import replace
 from typing import Dict, List, Optional
 
 from aioauth.models import AuthorizationCode, Client, Token
 from aioauth.requests import Request
-import time
 from aioauth.storage import BaseStorage
 from aioauth.types import TokenType
 
 from .models import Defaults
 
 
-class DB(BaseStorage[Token, Client, AuthorizationCode, Request]):
+class Storage(BaseStorage[Token, Client, AuthorizationCode, Request]):
     storage: Dict[str, List]
     defaults: Defaults
 
@@ -163,6 +164,6 @@ class DB(BaseStorage[Token, Client, AuthorizationCode, Request]):
 
 
 def get_db_class(defaults: Defaults, storage: Dict[str, List]):
-    DB.storage = storage
-    DB.defaults = defaults
-    return DB
+    Storage.storage = storage
+    Storage.defaults = defaults
+    return Storage

--- a/tests/classes.py
+++ b/tests/classes.py
@@ -1,14 +1,25 @@
 import time
 
-from dataclasses import replace
+from dataclasses import replace, dataclass
 from typing import Dict, List, Optional
 
 from aioauth.models import AuthorizationCode, Client, Token
-from aioauth.requests import Request
+from aioauth.requests import BaseRequest, Post, Query
 from aioauth.storage import BaseStorage
 from aioauth.types import CodeChallengeMethod, TokenType
 
 from .models import Defaults
+
+
+@dataclass
+class User:
+    first_name: str
+    last_name: str
+
+
+@dataclass
+class Request(BaseRequest[Query, Post, User]):
+    ...
 
 
 class Storage(BaseStorage[Token, Client, AuthorizationCode, Request]):

--- a/tests/classes.py
+++ b/tests/classes.py
@@ -10,7 +10,7 @@ from aioauth.types import TokenType
 from .models import Defaults
 
 
-class DB(BaseStorage[Token, Client, AuthorizationCode, Request]):
+class DB(BaseStorage[Token, Client, AuthorizationCode]):
     storage: Dict[str, List]
     defaults: Defaults
 

--- a/tests/classes.py
+++ b/tests/classes.py
@@ -10,7 +10,7 @@ from aioauth.types import TokenType
 from .models import Defaults
 
 
-class DB(BaseStorage[Token, Client, AuthorizationCode]):
+class DB(BaseStorage[Token, Client, AuthorizationCode, Request]):
     storage: Dict[str, List]
     defaults: Defaults
 

--- a/tests/classes.py
+++ b/tests/classes.py
@@ -6,7 +6,7 @@ from typing import Dict, List, Optional
 from aioauth.models import AuthorizationCode, Client, Token
 from aioauth.requests import Request
 from aioauth.storage import BaseStorage
-from aioauth.types import TokenType
+from aioauth.types import CodeChallengeMethod, TokenType
 
 from .models import Defaults
 
@@ -68,7 +68,7 @@ class Storage(BaseStorage[Token, Client, AuthorizationCode, Request]):
         self,
         request: Request,
         client_id: str,
-        token_type: Optional[str] = TokenType.REFRESH,
+        token_type: Optional[TokenType] = "refresh_token",
         access_token: Optional[str] = None,
         refresh_token: Optional[str] = None,
     ) -> Optional[Token]:
@@ -103,7 +103,7 @@ class Storage(BaseStorage[Token, Client, AuthorizationCode, Request]):
         scope: str,
         response_type: str,
         redirect_uri: str,
-        code_challenge_method: Optional[str],
+        code_challenge_method: Optional[CodeChallengeMethod],
         code_challenge: Optional[str],
         code: str,
     ):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,6 @@ from aioauth.response_type import (
     ResponseTypeToken,
 )
 from aioauth.server import AuthorizationServer
-from aioauth.types import CodeChallengeMethod, GrantType, ResponseType
 from aioauth.utils import generate_token
 
 from .classes import Storage, get_db_class
@@ -52,17 +51,17 @@ def storage(defaults: Defaults, settings: Settings) -> Dict:
         client_id=defaults.client_id,
         client_secret=defaults.client_secret,
         grant_types=[
-            GrantType.TYPE_AUTHORIZATION_CODE,
-            GrantType.TYPE_CLIENT_CREDENTIALS,
-            GrantType.TYPE_REFRESH_TOKEN,
-            GrantType.TYPE_PASSWORD,
+            "authorization_code",
+            "client_credentials",
+            "refresh_token",
+            "password",
         ],
         redirect_uris=[defaults.redirect_uri],
         response_types=[
-            ResponseType.TYPE_CODE,
-            ResponseType.TYPE_TOKEN,
-            ResponseType.TYPE_NONE,
-            ResponseType.TYPE_ID_TOKEN,
+            "code",
+            "token",
+            "none",
+            "id_token",
         ],
         scope=defaults.scope,
     )
@@ -70,11 +69,11 @@ def storage(defaults: Defaults, settings: Settings) -> Dict:
     authorization_code = AuthorizationCode(
         code=defaults.code,
         client_id=defaults.client_id,
-        response_type=ResponseType.TYPE_CODE,
+        response_type="code",
         auth_time=int(time.time()),
         redirect_uri=defaults.redirect_uri,
         scope=defaults.scope,
-        code_challenge_method=CodeChallengeMethod.PLAIN,
+        code_challenge_method="plain",
         expires_in=settings.AUTHORIZATION_CODE_EXPIRES_IN,
     )
 
@@ -110,20 +109,16 @@ def server(db: Storage) -> AuthorizationServer[Request, Storage]:
     server = AuthorizationServer[Request, Storage](
         storage=db,
         response_types={
-            ResponseType.TYPE_TOKEN: ResponseTypeToken[Request, Storage],
-            ResponseType.TYPE_CODE: ResponseTypeAuthorizationCode[Request, Storage],
-            ResponseType.TYPE_NONE: ResponseTypeNone[Request, Storage],
-            ResponseType.TYPE_ID_TOKEN: ResponseTypeIdToken[Request, Storage],
+            "token": ResponseTypeToken[Request, Storage],
+            "code": ResponseTypeAuthorizationCode[Request, Storage],
+            "none": ResponseTypeNone[Request, Storage],
+            "id_token": ResponseTypeIdToken[Request, Storage],
         },
         grant_types={
-            GrantType.TYPE_AUTHORIZATION_CODE: AuthorizationCodeGrantType[
-                Request, Storage
-            ],
-            GrantType.TYPE_CLIENT_CREDENTIALS: ClientCredentialsGrantType[
-                Request, Storage
-            ],
-            GrantType.TYPE_PASSWORD: PasswordGrantType[Request, Storage],
-            GrantType.TYPE_REFRESH_TOKEN: RefreshTokenGrantType[Request, Storage],
+            "authorization_code": AuthorizationCodeGrantType[Request, Storage],
+            "client_credentials": ClientCredentialsGrantType[Request, Storage],
+            "password": PasswordGrantType[Request, Storage],
+            "refresh_token": RefreshTokenGrantType[Request, Storage],
         },
     )
     return server

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,11 +19,10 @@ from aioauth.response_type import (
     ResponseTypeToken,
 )
 from aioauth.server import AuthorizationServer
-from aioauth.storage import BaseStorage
 from aioauth.types import CodeChallengeMethod, GrantType, ResponseType
 from aioauth.utils import generate_token
 
-from .classes import get_db_class
+from .classes import Storage, get_db_class
 from .models import Defaults
 
 
@@ -97,30 +96,34 @@ def storage(defaults: Defaults, settings: Settings) -> Dict:
 
 
 @pytest.fixture
-def db_class(defaults: Defaults, storage) -> Type[BaseStorage]:
+def db_class(defaults: Defaults, storage) -> Type[Storage]:
     return get_db_class(defaults, storage)
 
 
 @pytest.fixture
-def db(db_class: Type[BaseStorage]):
+def db(db_class: Type[Storage]):
     return db_class()
 
 
 @pytest.fixture
-def server(db: BaseStorage) -> AuthorizationServer[Request]:
-    server = AuthorizationServer[Request](
+def server(db: Storage) -> AuthorizationServer[Request, Storage]:
+    server = AuthorizationServer[Request, Storage](
         storage=db,
         response_types={
-            ResponseType.TYPE_TOKEN: ResponseTypeToken[Request],
-            ResponseType.TYPE_CODE: ResponseTypeAuthorizationCode[Request],
-            ResponseType.TYPE_NONE: ResponseTypeNone[Request],
-            ResponseType.TYPE_ID_TOKEN: ResponseTypeIdToken[Request],
+            ResponseType.TYPE_TOKEN: ResponseTypeToken[Request, Storage],
+            ResponseType.TYPE_CODE: ResponseTypeAuthorizationCode[Request, Storage],
+            ResponseType.TYPE_NONE: ResponseTypeNone[Request, Storage],
+            ResponseType.TYPE_ID_TOKEN: ResponseTypeIdToken[Request, Storage],
         },
         grant_types={
-            GrantType.TYPE_AUTHORIZATION_CODE: AuthorizationCodeGrantType[Request],
-            GrantType.TYPE_CLIENT_CREDENTIALS: ClientCredentialsGrantType[Request],
-            GrantType.TYPE_PASSWORD: PasswordGrantType[Request],
-            GrantType.TYPE_REFRESH_TOKEN: RefreshTokenGrantType[Request],
+            GrantType.TYPE_AUTHORIZATION_CODE: AuthorizationCodeGrantType[
+                Request, Storage
+            ],
+            GrantType.TYPE_CLIENT_CREDENTIALS: ClientCredentialsGrantType[
+                Request, Storage
+            ],
+            GrantType.TYPE_PASSWORD: PasswordGrantType[Request, Storage],
+            GrantType.TYPE_REFRESH_TOKEN: RefreshTokenGrantType[Request, Storage],
         },
     )
     return server

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ from aioauth.grant_type import (
     RefreshTokenGrantType,
 )
 from aioauth.models import AuthorizationCode, Client, Token
+from aioauth.requests import Request
 from aioauth.response_type import (
     ResponseTypeAuthorizationCode,
     ResponseTypeIdToken,
@@ -106,20 +107,20 @@ def db(db_class: Type[BaseStorage]):
 
 
 @pytest.fixture
-def server(db: BaseStorage) -> AuthorizationServer:
-    server = AuthorizationServer(
+def server(db: BaseStorage) -> AuthorizationServer[Request]:
+    server = AuthorizationServer[Request](
         storage=db,
         response_types={
-            ResponseType.TYPE_TOKEN: ResponseTypeToken,
-            ResponseType.TYPE_CODE: ResponseTypeAuthorizationCode,
-            ResponseType.TYPE_NONE: ResponseTypeNone,
-            ResponseType.TYPE_ID_TOKEN: ResponseTypeIdToken,
+            ResponseType.TYPE_TOKEN: ResponseTypeToken[Request],
+            ResponseType.TYPE_CODE: ResponseTypeAuthorizationCode[Request],
+            ResponseType.TYPE_NONE: ResponseTypeNone[Request],
+            ResponseType.TYPE_ID_TOKEN: ResponseTypeIdToken[Request],
         },
         grant_types={
-            GrantType.TYPE_AUTHORIZATION_CODE: AuthorizationCodeGrantType,
-            GrantType.TYPE_CLIENT_CREDENTIALS: ClientCredentialsGrantType,
-            GrantType.TYPE_PASSWORD: PasswordGrantType,
-            GrantType.TYPE_REFRESH_TOKEN: RefreshTokenGrantType,
+            GrantType.TYPE_AUTHORIZATION_CODE: AuthorizationCodeGrantType[Request],
+            GrantType.TYPE_CLIENT_CREDENTIALS: ClientCredentialsGrantType[Request],
+            GrantType.TYPE_PASSWORD: PasswordGrantType[Request],
+            GrantType.TYPE_REFRESH_TOKEN: RefreshTokenGrantType[Request],
         },
     )
     return server

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -15,6 +15,27 @@ async def test_db(storage):
     authorization_code: AuthorizationCode = storage["authorization_codes"][0]
 
     with pytest.raises(NotImplementedError):
+        await db.create_token(
+            request=request,
+            client_id=client.client_id,
+            scope="",
+            access_token=token.access_token,
+            refresh_token=token.refresh_token,
+        )
+
+    with pytest.raises(NotImplementedError):
+        await db.create_authorization_code(
+            request=request,
+            client_id=client.client_id,
+            scope="",
+            response_type="",
+            redirect_uri="",
+            code_challenge_method=None,
+            code_challenge=None,
+            code="123",
+        )
+
+    with pytest.raises(NotImplementedError):
         await db.get_token(
             request=request,
             client_id=client.client_id,

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -7,7 +7,7 @@ from aioauth.types import RequestMethod
 
 
 @pytest.mark.asyncio
-async def test_db(storage):
+async def test_storage_class(storage):
     db = BaseStorage()
     request = Request(method=RequestMethod.POST)
     client: Client = storage["clients"][0]

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -3,13 +3,12 @@ import pytest
 from aioauth.models import AuthorizationCode, Client, Token
 from aioauth.requests import Request
 from aioauth.storage import BaseStorage
-from aioauth.types import RequestMethod
 
 
 @pytest.mark.asyncio
 async def test_storage_class(storage):
     db = BaseStorage()
-    request = Request(method=RequestMethod.POST)
+    request = Request(method="POST")
     client: Client = storage["clients"][0]
     token: Token = storage["tokens"][0]
     authorization_code: AuthorizationCode = storage["authorization_codes"][0]
@@ -66,7 +65,7 @@ async def test_storage_class(storage):
             request=request,
             client_id=client.client_id,
             scope="",
-            response_type="",
+            response_type="token",
             redirect_uri="",
             nonce="",
         )

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -8,7 +8,6 @@ from aioauth.config import Settings
 from aioauth.models import Token
 from aioauth.requests import Post, Request
 from aioauth.server import AuthorizationServer
-from aioauth.storage import BaseStorage
 from aioauth.types import ErrorType, GrantType, RequestMethod, TokenType
 from aioauth.utils import (
     catch_errors_and_unavailability,
@@ -16,6 +15,7 @@ from aioauth.utils import (
     generate_token,
 )
 
+from .classes import Storage
 from .models import Defaults
 
 
@@ -154,8 +154,8 @@ async def test_introspect_revoked_token(
 
 
 @pytest.mark.asyncio
-async def test_endpoint_availability(db_class: Type[BaseStorage]):
-    server = AuthorizationServer(storage=db_class())
+async def test_endpoint_availability(db_class: Type[Storage]):
+    server = AuthorizationServer[Request, Storage](storage=db_class())
     request = Request(method=RequestMethod.POST, settings=Settings(AVAILABLE=False))
     response = await server.create_token_introspection_response(request)
     assert response.status_code == HTTPStatus.BAD_REQUEST

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -8,7 +8,6 @@ from aioauth.config import Settings
 from aioauth.models import Token
 from aioauth.requests import Post, Request
 from aioauth.server import AuthorizationServer
-from aioauth.types import ErrorType, GrantType, RequestMethod, TokenType
 from aioauth.utils import (
     catch_errors_and_unavailability,
     encode_auth_headers,
@@ -33,7 +32,7 @@ async def test_internal_server_error():
             raise Exception()
 
     e = EndpointClass()
-    response = await e.server(Request(method=RequestMethod.POST))
+    response = await e.server(Request(method="POST"))
     assert response.status_code == HTTPStatus.BAD_REQUEST
 
 
@@ -48,7 +47,7 @@ async def test_invalid_token(server: AuthorizationServer, defaults: Defaults):
     request = Request(
         url=request_url,
         post=post,
-        method=RequestMethod.POST,
+        method="POST",
         headers=encode_auth_headers(client_id, client_secret),
     )
     response = await server.create_token_introspection_response(request)
@@ -80,7 +79,7 @@ async def test_expired_token(
     request = Request(
         settings=settings,
         post=post,
-        method=RequestMethod.POST,
+        method="POST",
         headers=encode_auth_headers(client_id, client_secret),
     )
 
@@ -104,7 +103,7 @@ async def test_valid_token(
     post = Post(token=token.refresh_token)
     request = Request(
         post=post,
-        method=RequestMethod.POST,
+        method="POST",
         headers=encode_auth_headers(client_id, client_secret),
         settings=settings,
     )
@@ -128,25 +127,25 @@ async def test_introspect_revoked_token(
     token = storage["tokens"][0]
 
     post = Post(
-        grant_type=GrantType.TYPE_REFRESH_TOKEN,
+        grant_type="refresh_token",
         refresh_token=token.refresh_token,
     )
     request = Request(
         settings=settings,
         url=request_url,
         post=post,
-        method=RequestMethod.POST,
+        method="POST",
         headers=encode_auth_headers(client_id, client_secret),
     )
     response = await server.create_token_response(request)
     assert response.status_code == HTTPStatus.OK
 
     # Check that refreshed token was revoked
-    post = Post(token=token.access_token, token_type_hint=TokenType.ACCESS)
+    post = Post(token=token.access_token, token_type_hint="access_token")
     request = Request(
         settings=settings,
         post=post,
-        method=RequestMethod.POST,
+        method="POST",
         headers=encode_auth_headers(client_id, client_secret),
     )
     response = await server.create_token_introspection_response(request)
@@ -156,7 +155,7 @@ async def test_introspect_revoked_token(
 @pytest.mark.asyncio
 async def test_endpoint_availability(db_class: Type[Storage]):
     server = AuthorizationServer[Request, Storage](storage=db_class())
-    request = Request(method=RequestMethod.POST, settings=Settings(AVAILABLE=False))
+    request = Request(method="POST", settings=Settings(AVAILABLE=False))
     response = await server.create_token_introspection_response(request)
     assert response.status_code == HTTPStatus.BAD_REQUEST
-    assert response.content["error"] == ErrorType.TEMPORARILY_UNAVAILABLE
+    assert response.content["error"] == "temporarily_unavailable"

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -92,10 +92,10 @@ async def test_authorization_code_flow_plain_code_challenge(
     assert response.content["token_type"] == "Bearer"
     # Check that token was created in db
     assert await db.get_token(
-        request,
-        client_id,
-        response.content["access_token"],
-        response.content["refresh_token"],
+        request=request,
+        client_id=client_id,
+        access_token=response.content["access_token"],
+        refresh_token=response.content["refresh_token"],
     )
 
     access_token = response.content["access_token"]
@@ -121,21 +121,26 @@ async def test_authorization_code_flow_plain_code_challenge(
     assert response.content["refresh_token"] != refresh_token
     # Check that token was created in db
     assert await db.get_token(
-        request,
-        client_id,
-        response.content["access_token"],
-        response.content["refresh_token"],
+        request=request,
+        client_id=client_id,
+        access_token=response.content["access_token"],
+        refresh_token=response.content["refresh_token"],
     )
     # Check that previous token was revoken
-    token_in_db = await db.get_token(request, client_id, access_token, refresh_token)
+    token_in_db = await db.get_token(
+        request=request,
+        client_id=client_id,
+        access_token=access_token,
+        refresh_token=refresh_token,
+    )
     assert token_in_db.revoked
 
     # check that scope is previous scope
     new_token = await db.get_token(
-        request,
-        client_id,
-        response.content["access_token"],
-        response.content["refresh_token"],
+        request=request,
+        client_id=client_id,
+        access_token=response.content["access_token"],
+        refresh_token=response.content["refresh_token"],
     )
     assert set(enforce_list(new_token.scope)) == set(enforce_list(token_in_db.scope))
 

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -133,7 +133,7 @@ async def test_authorization_code_flow_plain_code_challenge(
         access_token=access_token,
         refresh_token=refresh_token,
     )
-    assert token_in_db.revoked
+    assert token_in_db.revoked  # type: ignore
 
     # check that scope is previous scope
     new_token = await db.get_token(
@@ -142,7 +142,7 @@ async def test_authorization_code_flow_plain_code_challenge(
         access_token=response.content["access_token"],
         refresh_token=response.content["refresh_token"],
     )
-    assert set(enforce_list(new_token.scope)) == set(enforce_list(token_in_db.scope))
+    assert set(enforce_list(new_token.scope)) == set(enforce_list(token_in_db.scope))  # type: ignore
 
 
 @pytest.mark.asyncio

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -7,13 +7,6 @@ from aioauth.constances import default_headers
 from aioauth.requests import Post, Query, Request
 from aioauth.server import AuthorizationServer
 from aioauth.storage import BaseStorage
-from aioauth.types import (
-    CodeChallengeMethod,
-    GrantType,
-    RequestMethod,
-    ResponseMode,
-    ResponseType,
-)
 from aioauth.utils import (
     create_s256_code_challenge,
     encode_auth_headers,
@@ -39,17 +32,17 @@ async def test_authorization_code_flow_plain_code_challenge(
 
     query = Query(
         client_id=defaults.client_id,
-        response_type=ResponseType.TYPE_CODE,
+        response_type="code",
         redirect_uri=redirect_uri,
         scope=scope,
-        code_challenge_method=CodeChallengeMethod.PLAIN,
+        code_challenge_method="plain",
         code_challenge=code_challenge,
     )
 
     request = Request(
         url=request_url,
         query=query,
-        method=RequestMethod.GET,
+        method="GET",
         user=user,
     )
 
@@ -69,7 +62,7 @@ async def test_authorization_code_flow_plain_code_challenge(
     code = query["code"]
 
     post = Post(
-        grant_type=GrantType.TYPE_AUTHORIZATION_CODE,
+        grant_type="authorization_code",
         redirect_uri=defaults.redirect_uri,
         code=code,
         code_verifier=code_challenge,
@@ -79,7 +72,7 @@ async def test_authorization_code_flow_plain_code_challenge(
     request = Request(
         url=request_url,
         post=post,
-        method=RequestMethod.POST,
+        method="POST",
         headers=encode_auth_headers(client_id, client_secret),
     )
 
@@ -102,7 +95,7 @@ async def test_authorization_code_flow_plain_code_challenge(
     refresh_token = response.content["refresh_token"]
 
     post = Post(
-        grant_type=GrantType.TYPE_REFRESH_TOKEN,
+        grant_type="refresh_token",
         refresh_token=refresh_token,
         scope=scope,
     )
@@ -110,7 +103,7 @@ async def test_authorization_code_flow_plain_code_challenge(
     request = Request(
         url=request_url,
         post=post,
-        method=RequestMethod.POST,
+        method="POST",
         headers=encode_auth_headers(client_id, client_secret),
     )
     await check_request_validators(request, server.create_token_response)
@@ -160,18 +153,18 @@ async def test_authorization_code_flow_pkce_code_challenge(
 
     query = Query(
         client_id=defaults.client_id,
-        response_type=ResponseType.TYPE_CODE,
+        response_type="code",
         redirect_uri=defaults.redirect_uri,
         scope=scope,
         state=state,
-        code_challenge_method=CodeChallengeMethod.S256,
+        code_challenge_method="S256",
         code_challenge=code_challenge,
     )
 
     request = Request(
         url=request_url,
         query=query,
-        method=RequestMethod.GET,
+        method="GET",
         user=user,
     )
     response = await server.create_authorization_response(request)
@@ -185,7 +178,7 @@ async def test_authorization_code_flow_pkce_code_challenge(
     code = query["code"]
 
     post = Post(
-        grant_type=GrantType.TYPE_AUTHORIZATION_CODE,
+        grant_type="authorization_code",
         redirect_uri=defaults.redirect_uri,
         code=code,
         scope=scope,
@@ -195,7 +188,7 @@ async def test_authorization_code_flow_pkce_code_challenge(
     request = Request(
         url=request_url,
         post=post,
-        method=RequestMethod.POST,
+        method="POST",
         headers=encode_auth_headers(client_id, client_secret),
     )
 
@@ -223,7 +216,7 @@ async def test_implicit_flow(server: AuthorizationServer, defaults: Defaults):
 
     query = Query(
         client_id=defaults.client_id,
-        response_type=ResponseType.TYPE_TOKEN,
+        response_type="token",
         redirect_uri=defaults.redirect_uri,
         scope=scope,
         state=state,
@@ -232,7 +225,7 @@ async def test_implicit_flow(server: AuthorizationServer, defaults: Defaults):
     request = Request(
         url=request_url,
         query=query,
-        method=RequestMethod.GET,
+        method="GET",
         user=user,
     )
 
@@ -252,7 +245,7 @@ async def test_password_grant_type(server: AuthorizationServer, defaults: Defaul
     request_url = "https://localhost"
 
     post = Post(
-        grant_type=GrantType.TYPE_PASSWORD,
+        grant_type="password",
         username=defaults.username,
         password=defaults.password,
     )
@@ -260,7 +253,7 @@ async def test_password_grant_type(server: AuthorizationServer, defaults: Defaul
     request = Request(
         post=post,
         url=request_url,
-        method=RequestMethod.POST,
+        method="POST",
         headers=encode_auth_headers(client_id, client_secret),
     )
 
@@ -278,7 +271,7 @@ async def test_authorization_code_flow(server: AuthorizationServer, defaults: De
 
     query = Query(
         client_id=defaults.client_id,
-        response_type=ResponseType.TYPE_CODE,
+        response_type="code",
         redirect_uri=defaults.redirect_uri,
         scope=defaults.scope,
         state=generate_token(10),
@@ -287,7 +280,7 @@ async def test_authorization_code_flow(server: AuthorizationServer, defaults: De
     request = Request(
         url=request_url,
         query=query,
-        method=RequestMethod.GET,
+        method="GET",
         user=user,
     )
 
@@ -302,7 +295,7 @@ async def test_authorization_code_flow(server: AuthorizationServer, defaults: De
     code = query["code"]
 
     post = Post(
-        grant_type=GrantType.TYPE_AUTHORIZATION_CODE,
+        grant_type="authorization_code",
         redirect_uri=defaults.redirect_uri,
         code=code,
     )
@@ -310,7 +303,7 @@ async def test_authorization_code_flow(server: AuthorizationServer, defaults: De
     request = Request(
         url=request_url,
         post=post,
-        method=RequestMethod.POST,
+        method="POST",
         headers=encode_auth_headers(client_id, client_secret),
     )
 
@@ -331,7 +324,7 @@ async def test_authorization_code_flow_credentials_in_post(
 
     query = Query(
         client_id=defaults.client_id,
-        response_type=ResponseType.TYPE_CODE,
+        response_type="code",
         redirect_uri=defaults.redirect_uri,
         scope=defaults.scope,
         state=generate_token(10),
@@ -340,7 +333,7 @@ async def test_authorization_code_flow_credentials_in_post(
     request = Request(
         url=request_url,
         query=query,
-        method=RequestMethod.GET,
+        method="GET",
         user=user,
     )
 
@@ -355,7 +348,7 @@ async def test_authorization_code_flow_credentials_in_post(
     code = query["code"]
 
     post = Post(
-        grant_type=GrantType.TYPE_AUTHORIZATION_CODE,
+        grant_type="authorization_code",
         client_id=client_id,
         client_secret=client_secret,
         redirect_uri=defaults.redirect_uri,
@@ -365,7 +358,7 @@ async def test_authorization_code_flow_credentials_in_post(
     request = Request(
         url=request_url,
         post=post,
-        method=RequestMethod.POST,
+        method="POST",
     )
 
     response = await server.create_token_response(request)
@@ -379,13 +372,13 @@ async def test_client_credentials_flow_post_data(
     request_url = "https://localhost"
 
     post = Post(
-        grant_type=GrantType.TYPE_CLIENT_CREDENTIALS,
+        grant_type="client_credentials",
         client_id=defaults.client_id,
         client_secret=defaults.client_secret,
         scope=defaults.scope,
     )
 
-    request = Request(url=request_url, post=post, method=RequestMethod.POST)
+    request = Request(url=request_url, post=post, method="POST")
 
     await check_request_validators(request, server.create_token_response)
 
@@ -400,14 +393,14 @@ async def test_client_credentials_flow_auth_header(
     request_url = "https://localhost"
 
     post = Post(
-        grant_type=GrantType.TYPE_CLIENT_CREDENTIALS,
+        grant_type="client_credentials",
         scope=defaults.scope,
     )
 
     request = Request(
         url=request_url,
         post=post,
-        method=RequestMethod.POST,
+        method="POST",
         headers=encode_auth_headers(
             client_id=defaults.client_id, client_secret=defaults.client_secret
         ),
@@ -426,7 +419,7 @@ async def test_multiple_response_types(server: AuthorizationServer, defaults: De
 
     query = Query(
         client_id=defaults.client_id,
-        response_type=f"{ResponseType.TYPE_CODE} {ResponseType.TYPE_TOKEN}",
+        response_type="code token",
         redirect_uri=defaults.redirect_uri,
         scope=defaults.scope,
         state=generate_token(10),
@@ -435,7 +428,7 @@ async def test_multiple_response_types(server: AuthorizationServer, defaults: De
     request = Request(
         url=request_url,
         query=query,
-        method=RequestMethod.GET,
+        method="GET",
         user=user,
     )
 
@@ -464,7 +457,7 @@ async def test_response_type_none(server: AuthorizationServer, defaults: Default
 
     query = Query(
         client_id=defaults.client_id,
-        response_type=ResponseType.TYPE_NONE,
+        response_type="none",
         redirect_uri=defaults.redirect_uri,
         scope=defaults.scope,
         state=generate_token(10),
@@ -473,7 +466,7 @@ async def test_response_type_none(server: AuthorizationServer, defaults: Default
     request = Request(
         url=request_url,
         query=query,
-        method=RequestMethod.GET,
+        method="GET",
         user=user,
     )
 
@@ -493,9 +486,9 @@ async def test_response_type_none(server: AuthorizationServer, defaults: Default
 @pytest.mark.parametrize(
     "response_mode,",
     [
-        ResponseMode.MODE_FORM_POST,
-        ResponseMode.MODE_FRAGMENT,
-        ResponseMode.MODE_QUERY,
+        "query",
+        "form_post",
+        "fragment",
         None,
     ],
 )
@@ -507,7 +500,7 @@ async def test_response_type_id_token(
 
     query = Query(
         client_id=defaults.client_id,
-        response_type=f"{ResponseType.TYPE_CODE} {ResponseType.TYPE_TOKEN} {ResponseType.TYPE_ID_TOKEN}",
+        response_type="code token id_token",
         redirect_uri=defaults.redirect_uri,
         scope=defaults.scope,
         state=generate_token(10),
@@ -518,7 +511,7 @@ async def test_response_type_id_token(
     request = Request(
         url=request_url,
         query=query,
-        method=RequestMethod.GET,
+        method="GET",
         user=user,
     )
 
@@ -531,7 +524,7 @@ async def test_response_type_id_token(
     fragment = dict(parse_qsl(location.fragment))
     query = dict(parse_qsl(location.query))
 
-    if response_mode == ResponseMode.MODE_FRAGMENT:
+    if response_mode == "fragment":
         assert "state" in fragment
         assert "expires_in" in fragment
         assert "refresh_token_expires_in" in fragment
@@ -541,7 +534,7 @@ async def test_response_type_id_token(
         assert "token_type" in fragment
         assert "code" in fragment
         assert "id_token" in fragment
-    elif response_mode == ResponseMode.MODE_FORM_POST:
+    elif response_mode == "form_post":
         assert "state" in response.content
         assert "expires_in" in response.content
         assert "refresh_token_expires_in" in response.content
@@ -551,7 +544,7 @@ async def test_response_type_id_token(
         assert "token_type" in response.content
         assert "code" in response.content
         assert "id_token" in response.content
-    elif response_mode == ResponseMode.MODE_QUERY:
+    elif response_mode == "query":
         assert "state" in query
         assert "expires_in" in query
         assert "refresh_token_expires_in" in query

--- a/tests/test_grant_type.py
+++ b/tests/test_grant_type.py
@@ -9,10 +9,11 @@ from aioauth.grant_type import RefreshTokenGrantType
 from aioauth.models import AuthorizationCode, Client, Token
 from aioauth.requests import Post, Request
 from aioauth.server import AuthorizationServer
-from aioauth.storage import BaseStorage
 from aioauth.types import CodeChallengeMethod, GrantType, RequestMethod, ResponseType
 from aioauth.utils import encode_auth_headers
-from tests.models import Defaults
+
+from .classes import Storage
+from .models import Defaults
 
 
 @pytest.fixture
@@ -61,7 +62,7 @@ def storage(defaults: Defaults, settings: Settings) -> Dict:
 
 @pytest.mark.asyncio
 async def test_refresh_token_grant_type(
-    server: AuthorizationServer, defaults: Defaults, db: BaseStorage
+    server: AuthorizationServer, defaults: Defaults, db: Storage
 ):
     # first create an access token
 
@@ -82,7 +83,7 @@ async def test_refresh_token_grant_type(
         headers=encode_auth_headers(client_id, client_secret),
     )
 
-    grant_type = RefreshTokenGrantType(
+    grant_type = RefreshTokenGrantType[Request, Storage](
         db, client_id=defaults.client_id, client_secret=defaults.client_secret
     )
 

--- a/tests/test_grant_type.py
+++ b/tests/test_grant_type.py
@@ -9,7 +9,6 @@ from aioauth.grant_type import RefreshTokenGrantType
 from aioauth.models import AuthorizationCode, Client, Token
 from aioauth.requests import Post, Request
 from aioauth.server import AuthorizationServer
-from aioauth.types import CodeChallengeMethod, GrantType, RequestMethod, ResponseType
 from aioauth.utils import encode_auth_headers
 
 from .classes import Storage
@@ -22,24 +21,24 @@ def storage(defaults: Defaults, settings: Settings) -> Dict:
         client_id=defaults.client_id,
         client_secret=defaults.client_secret,
         grant_types=[
-            GrantType.TYPE_AUTHORIZATION_CODE,
-            GrantType.TYPE_CLIENT_CREDENTIALS,
-            GrantType.TYPE_REFRESH_TOKEN,
-            GrantType.TYPE_PASSWORD,
+            "authorization_code",
+            "password",
+            "client_credentials",
+            "refresh_token",
         ],
         redirect_uris=[defaults.redirect_uri],
-        response_types=[ResponseType.TYPE_CODE, ResponseType.TYPE_TOKEN],
+        response_types=["code", "token"],
         scope="read write foo",
     )
 
     authorization_code = AuthorizationCode(
         code=defaults.code,
         client_id=defaults.client_id,
-        response_type=ResponseType.TYPE_CODE,
+        response_type="code",
         auth_time=int(time.time()),
         redirect_uri=defaults.redirect_uri,
         scope="read write",
-        code_challenge_method=CodeChallengeMethod.PLAIN,
+        code_challenge_method="plain",
         expires_in=settings.AUTHORIZATION_CODE_EXPIRES_IN,
     )
 
@@ -71,7 +70,7 @@ async def test_refresh_token_grant_type(
     request_url = "https://localhost"
 
     post = Post(
-        grant_type=GrantType.TYPE_REFRESH_TOKEN,
+        grant_type="refresh_token",
         refresh_token=defaults.refresh_token,
         scope="read foo",
     )
@@ -79,7 +78,7 @@ async def test_refresh_token_grant_type(
     request = Request(
         url=request_url,
         post=post,
-        method=RequestMethod.POST,
+        method="POST",
         headers=encode_auth_headers(client_id, client_secret),
     )
 

--- a/tests/test_grant_type.py
+++ b/tests/test_grant_type.py
@@ -100,7 +100,7 @@ async def test_refresh_token_grant_type(
         access_token=defaults.access_token,
         refresh_token=defaults.refresh_token,
     )
-    assert token_in_db.revoked
+    assert token_in_db.revoked  # type: ignore
     assert token_response.scope == "read"
 
     with pytest.raises(InvalidGrantError):

--- a/tests/test_grant_type.py
+++ b/tests/test_grant_type.py
@@ -95,7 +95,10 @@ async def test_refresh_token_grant_type(
 
     # Check that previous token was revoken
     token_in_db = await db.get_token(
-        request, client_id, defaults.access_token, defaults.refresh_token
+        request=request,
+        client_id=client_id,
+        access_token=defaults.access_token,
+        refresh_token=defaults.refresh_token,
     )
     assert token_in_db.revoked
     assert token_response.scope == "read"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,7 +7,6 @@ from aioauth.collections import HTTPHeaderDict
 from aioauth.config import Settings
 from aioauth.errors import InvalidClientError
 from aioauth.requests import Request
-from aioauth.types import RequestMethod
 from aioauth.utils import (
     build_uri,
     decode_auth_headers,
@@ -37,7 +36,7 @@ def test_build_uri():
 
 
 def test_decode_auth_headers():
-    request = Request(headers=HTTPHeaderDict(), method=RequestMethod.POST)
+    request = Request(headers=HTTPHeaderDict(), method="POST")
     authorization = request.headers.get("Authorization", "")
 
     # No authorization header
@@ -60,7 +59,7 @@ def test_decode_auth_headers():
 
 def test_base_error_uri():
     ERROR_URI = "https://google.com"
-    request = Request(settings=Settings(ERROR_URI=ERROR_URI), method=RequestMethod.POST)
+    request = Request(settings=Settings(ERROR_URI=ERROR_URI), method="POST")
 
     try:
         raise InvalidClientError(request=request)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,14 +6,13 @@ from aioauth.collections import HTTPHeaderDict
 from aioauth.constances import default_headers
 from aioauth.requests import Post, Query, Request
 from aioauth.responses import ErrorResponse, Response
-from aioauth.types import ErrorType, RequestMethod
 
 EMPTY_KEYS = {
-    RequestMethod.GET: {
+    "GET": {
         "client_id": Response(
             content=asdict(
                 ErrorResponse(
-                    error=ErrorType.INVALID_REQUEST,
+                    error="invalid_request",
                     description="Missing client_id parameter.",
                 )
             ),
@@ -23,7 +22,7 @@ EMPTY_KEYS = {
         "response_type": Response(
             content=asdict(
                 ErrorResponse(
-                    error=ErrorType.INVALID_REQUEST,
+                    error="invalid_request",
                     description="Missing response_type parameter.",
                 )
             ),
@@ -33,7 +32,7 @@ EMPTY_KEYS = {
         "redirect_uri": Response(
             content=asdict(
                 ErrorResponse(
-                    error=ErrorType.INVALID_REQUEST,
+                    error="invalid_request",
                     description="Mismatching redirect URI.",
                 )
             ),
@@ -43,7 +42,7 @@ EMPTY_KEYS = {
         "code_challenge": Response(
             content=asdict(
                 ErrorResponse(
-                    error=ErrorType.INVALID_REQUEST,
+                    error="invalid_request",
                     description="Code challenge required.",
                 )
             ),
@@ -53,7 +52,7 @@ EMPTY_KEYS = {
         "nonce": Response(
             content=asdict(
                 ErrorResponse(
-                    error=ErrorType.INVALID_REQUEST,
+                    error="invalid_request",
                     description="Nonce required for response_type id_token.",
                 )
             ),
@@ -61,11 +60,11 @@ EMPTY_KEYS = {
             headers=default_headers,
         ),
     },
-    RequestMethod.POST: {
+    "POST": {
         "grant_type": Response(
             content=asdict(
                 ErrorResponse(
-                    error=ErrorType.INVALID_REQUEST,
+                    error="invalid_request",
                     description="Request is missing grant type.",
                 )
             ),
@@ -75,7 +74,7 @@ EMPTY_KEYS = {
         "redirect_uri": Response(
             content=asdict(
                 ErrorResponse(
-                    error=ErrorType.INVALID_REQUEST,
+                    error="invalid_request",
                     description="Mismatching redirect URI.",
                 )
             ),
@@ -85,7 +84,7 @@ EMPTY_KEYS = {
         "code": Response(
             content=asdict(
                 ErrorResponse(
-                    error=ErrorType.INVALID_REQUEST,
+                    error="invalid_request",
                     description="Missing code parameter.",
                 )
             ),
@@ -95,7 +94,7 @@ EMPTY_KEYS = {
         "refresh_token": Response(
             content=asdict(
                 ErrorResponse(
-                    error=ErrorType.INVALID_REQUEST,
+                    error="invalid_request",
                     description="Missing refresh token parameter.",
                 )
             ),
@@ -105,7 +104,7 @@ EMPTY_KEYS = {
         "code_verifier": Response(
             content=asdict(
                 ErrorResponse(
-                    error=ErrorType.INVALID_REQUEST,
+                    error="invalid_request",
                     description="Code verifier required.",
                 )
             ),
@@ -115,7 +114,7 @@ EMPTY_KEYS = {
         "client_id": Response(
             content=asdict(
                 ErrorResponse(
-                    error=ErrorType.INVALID_CLIENT,
+                    error="invalid_client",
                     description="",
                 )
             ),
@@ -125,7 +124,7 @@ EMPTY_KEYS = {
         "client_secret": Response(
             content=asdict(
                 ErrorResponse(
-                    error=ErrorType.INVALID_CLIENT,
+                    error="invalid_client",
                     description="",
                 )
             ),
@@ -135,7 +134,7 @@ EMPTY_KEYS = {
         "username": Response(
             content=asdict(
                 ErrorResponse(
-                    error=ErrorType.INVALID_REQUEST,
+                    error="invalid_request",
                     description="Invalid credentials given.",
                 )
             ),
@@ -145,7 +144,7 @@ EMPTY_KEYS = {
         "password": Response(
             content=asdict(
                 ErrorResponse(
-                    error=ErrorType.INVALID_REQUEST,
+                    error="invalid_request",
                     description="Invalid credentials given.",
                 )
             ),
@@ -156,11 +155,11 @@ EMPTY_KEYS = {
 }
 
 INVALID_KEYS = {
-    RequestMethod.GET: {
+    "GET": {
         "client_id": Response(
             content=asdict(
                 ErrorResponse(
-                    error=ErrorType.INVALID_REQUEST,
+                    error="invalid_request",
                     description="Invalid client_id parameter value.",
                 )
             ),
@@ -170,7 +169,7 @@ INVALID_KEYS = {
         "response_type": Response(
             content=asdict(
                 ErrorResponse(
-                    error=ErrorType.UNSUPPORTED_RESPONSE_TYPE,
+                    error="unsupported_response_type",
                     description="",
                 )
             ),
@@ -180,7 +179,7 @@ INVALID_KEYS = {
         "redirect_uri": Response(
             content=asdict(
                 ErrorResponse(
-                    error=ErrorType.INVALID_REQUEST,
+                    error="invalid_request",
                     description="Invalid redirect URI.",
                 )
             ),
@@ -190,7 +189,7 @@ INVALID_KEYS = {
         "code_challenge_method": Response(
             content=asdict(
                 ErrorResponse(
-                    error=ErrorType.INVALID_REQUEST,
+                    error="invalid_request",
                     description="Transform algorithm not supported.",
                 )
             ),
@@ -200,7 +199,7 @@ INVALID_KEYS = {
         "scope": Response(
             content=asdict(
                 ErrorResponse(
-                    error=ErrorType.INVALID_SCOPE,
+                    error="invalid_scope",
                     description="",
                 )
             ),
@@ -208,11 +207,11 @@ INVALID_KEYS = {
             headers=default_headers,
         ),
     },
-    RequestMethod.POST: {
+    "POST": {
         "grant_type": Response(
             content=asdict(
                 ErrorResponse(
-                    error=ErrorType.UNSUPPORTED_GRANT_TYPE,
+                    error="unsupported_grant_type",
                     description="",
                 )
             ),
@@ -222,7 +221,7 @@ INVALID_KEYS = {
         "redirect_uri": Response(
             content=asdict(
                 ErrorResponse(
-                    error=ErrorType.INVALID_REQUEST,
+                    error="invalid_request",
                     description="Invalid redirect URI.",
                 )
             ),
@@ -232,7 +231,7 @@ INVALID_KEYS = {
         "code": Response(
             content=asdict(
                 ErrorResponse(
-                    error=ErrorType.INVALID_GRANT,
+                    error="invalid_grant",
                     description="",
                 )
             ),
@@ -242,7 +241,7 @@ INVALID_KEYS = {
         "code_verifier": Response(
             content=asdict(
                 ErrorResponse(
-                    error=ErrorType.MISMATCHING_STATE,
+                    error="mismatching_state",
                     description="CSRF Warning! State not equal in request and response.",
                 )
             ),
@@ -252,7 +251,7 @@ INVALID_KEYS = {
         "refresh_token": Response(
             content=asdict(
                 ErrorResponse(
-                    error=ErrorType.INVALID_GRANT,
+                    error="invalid_grant",
                     description="",
                 )
             ),
@@ -262,7 +261,7 @@ INVALID_KEYS = {
         "client_id": Response(
             content=asdict(
                 ErrorResponse(
-                    error=ErrorType.INVALID_REQUEST,
+                    error="invalid_request",
                     description="Invalid client_id parameter value.",
                 )
             ),
@@ -272,7 +271,7 @@ INVALID_KEYS = {
         "client_secret": Response(
             content=asdict(
                 ErrorResponse(
-                    error=ErrorType.INVALID_REQUEST,
+                    error="invalid_request",
                     description="Invalid client_id parameter value.",
                 )
             ),
@@ -282,7 +281,7 @@ INVALID_KEYS = {
         "username": Response(
             content=asdict(
                 ErrorResponse(
-                    error=ErrorType.INVALID_REQUEST,
+                    error="invalid_request",
                     description="Invalid credentials given.",
                 )
             ),
@@ -292,7 +291,7 @@ INVALID_KEYS = {
         "password": Response(
             content=asdict(
                 ErrorResponse(
-                    error=ErrorType.INVALID_REQUEST,
+                    error="invalid_request",
                     description="Invalid credentials given.",
                 )
             ),
@@ -316,11 +315,11 @@ async def check_query_values(
     for key in keys:
         request_ = request
 
-        if request_.method == RequestMethod.POST:
+        if request_.method == "POST":
             post = replace(request_.post, **{key: value})
             request_ = replace(request_, post=post)
 
-        if request_.method == RequestMethod.GET:
+        if request_.method == "GET":
             query = replace(request_.query, **{key: value})
             request_ = replace(request_, query=query)
 
@@ -338,10 +337,10 @@ async def check_request_validators(
 ):
     query_dict = {}
 
-    if request.method == RequestMethod.POST:
+    if request.method == "POST":
         query_dict = get_keys(request.post)
 
-    if request.method == RequestMethod.GET:
+    if request.method == "GET":
         query_dict = get_keys(request.query)
 
     responses = EMPTY_KEYS[request.method]


### PR DESCRIPTION
see the issue #63

while inheriting from models (Token, Client, AuthorizationCode), and using them in aioauth, mypy throws an error like:

```
error: Argument 1 of "create_authorization_code" is incompatible with supertype "BaseStorage"; supertype defines the argument type as "Request"
```

this PR fixes the above bug by adding additional `TToken`, `TClient` and `TAuthorizationCode` parameters to the `BaseModel` generic.

usage example:

```python
from dataclasses import dataclass
from aioauth_fastapi.router import get_oauth2_router
from aioauth.storage import BaseStorage
from aioauth.requests import BaseRequest
from aioauth.models import AuthorizationCode, Client, Token
from aioauth.config import Settings
from aioauth.server import AuthorizationServer
from fastapi import FastAPI

app = FastAPI()

@dataclass
class User:
    """Custom user model"""
    first_name: str
    last_name: str


@dataclass
class Request(BaseRequest[Query, Post, User]):
    """"Custom request"""


class Storage(BaseStorage[Token, Client, AuthorizationCode, Request]):
    """
    Storage methods must be implemented here.
    """

storage = Storage()
authorization_server = AuthorizationServer[Request, Storage](storage)

# NOTE: Redefinition of the default aioauth settings
# INSECURE_TRANSPORT must be enabled for local development only!
settings = Settings(
    INSECURE_TRANSPORT=True,
)

# Include FastAPI router with oauth2 endpoints.
app.include_router(
    get_oauth2_router(authorization_server, settings),
    prefix="/oauth2",
    tags=["oauth2"],
)
```