### PR TITLE
Return most /authorize errors as a redirect

### DIFF
--- a/aioauth/errors.py
+++ b/aioauth/errors.py
@@ -171,3 +171,11 @@ class TemporarilyUnavailableError(OAuth2Error[TRequest]):
     """
 
     error: Literal["temporarily_unavailable"] = "temporarily_unavailable"
+
+
+class InvalidRedirectURIError(OAuth2Error[TRequest]):
+    """
+    The requested redirect URI is missing or not allowed.
+    """
+
+    error: Literal["invalid_request"] = "invalid_request"

--- a/aioauth/grant_type.py
+++ b/aioauth/grant_type.py
@@ -9,7 +9,9 @@ Different OAuth 2.0 grant types.
 """
 from typing import Generic
 from .errors import (
+    InvalidClientError,
     InvalidGrantError,
+    InvalidRedirectURIError,
     InvalidRequestError,
     InvalidScopeError,
     MismatchingStateError,
@@ -58,7 +60,7 @@ class GrantTypeBase(Generic[TRequest, TStorage]):
         )
 
         if not client:
-            raise InvalidRequestError[TRequest](
+            raise InvalidClientError[TRequest](
                 request=request, description="Invalid client_id parameter value."
             )
 
@@ -91,12 +93,12 @@ class AuthorizationCodeGrantType(GrantTypeBase[TRequest, TStorage]):
         client = await super().validate_request(request)
 
         if not request.post.redirect_uri:
-            raise InvalidRequestError[TRequest](
+            raise InvalidRedirectURIError[TRequest](
                 request=request, description="Mismatching redirect URI."
             )
 
         if not client.check_redirect_uri(request.post.redirect_uri):
-            raise InvalidRequestError[TRequest](
+            raise InvalidRedirectURIError[TRequest](
                 request=request, description="Invalid redirect URI."
             )
 

--- a/aioauth/response_type.py
+++ b/aioauth/response_type.py
@@ -12,6 +12,7 @@ from typing import Generic, List
 from .utils import generate_token
 from .errors import (
     InvalidClientError,
+    InvalidRedirectURIError,
     InvalidRequestError,
     InvalidScopeError,
     UnsupportedResponseTypeError,
@@ -38,7 +39,7 @@ class ResponseTypeBase(Generic[TRequest, TStorage]):
         code_challenge_methods: List[CodeChallengeMethod] = ["plain", "S256"]
 
         if not request.query.client_id:
-            raise InvalidRequestError[TRequest](
+            raise InvalidClientError[TRequest](
                 request=request, description="Missing client_id parameter."
             )
 
@@ -47,17 +48,17 @@ class ResponseTypeBase(Generic[TRequest, TStorage]):
         )
 
         if not client:
-            raise InvalidRequestError[TRequest](
+            raise InvalidClientError[TRequest](
                 request=request, description="Invalid client_id parameter value."
             )
 
         if not request.query.redirect_uri:
-            raise InvalidRequestError[TRequest](
+            raise InvalidRedirectURIError[TRequest](
                 request=request, description="Mismatching redirect URI."
             )
 
         if not client.check_redirect_uri(request.query.redirect_uri):
-            raise InvalidRequestError[TRequest](
+            raise InvalidRedirectURIError[TRequest](
                 request=request, description="Invalid redirect URI."
             )
 

--- a/aioauth/server.py
+++ b/aioauth/server.py
@@ -125,7 +125,7 @@ class AuthorizationServer(Generic[TRequest, TStorage]):
             )
             raise MethodNotAllowedError[TRequest](request=request, headers=headers)
 
-    @catch_errors_and_unavailability
+    @catch_errors_and_unavailability()
     async def create_token_introspection_response(self, request: TRequest) -> Response:
         """
         Returns a response object with introspection of the passed token.
@@ -219,7 +219,7 @@ class AuthorizationServer(Generic[TRequest, TStorage]):
 
         return client_id, client_secret
 
-    @catch_errors_and_unavailability
+    @catch_errors_and_unavailability()
     async def create_token_response(self, request: TRequest) -> Response:
         """Endpoint to obtain an access and/or ID token by presenting an
         authorization grant or refresh token.
@@ -290,7 +290,7 @@ class AuthorizationServer(Generic[TRequest, TStorage]):
             content=content, status_code=HTTPStatus.OK, headers=default_headers
         )
 
-    @catch_errors_and_unavailability
+    @catch_errors_and_unavailability(redirect=True)
     async def create_authorization_response(self, request: TRequest) -> Response:
         """
         Endpoint to interact with the resource owner and obtain an

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -27,7 +27,7 @@ async def test_internal_server_error():
             if available is not None:
                 self.available = available
 
-        @catch_errors_and_unavailability
+        @catch_errors_and_unavailability()
         async def server(self, request):
             raise Exception()
 

--- a/tests/test_request_validator.py
+++ b/tests/test_request_validator.py
@@ -2,6 +2,7 @@ import time
 from dataclasses import replace
 from http import HTTPStatus
 from typing import Dict, List
+from urllib.parse import urlparse, parse_qs
 
 import pytest
 
@@ -25,7 +26,9 @@ async def test_insecure_transport_error(server: AuthorizationServer):
     request = Request(url=request_url, method="GET")
 
     response = await server.create_authorization_response(request)
-    assert response.status_code == HTTPStatus.BAD_REQUEST
+    assert response.status_code == HTTPStatus.FOUND
+    query_params = parse_qs(urlparse(response.headers["Location"]).query)
+    assert query_params["error"] == ["insecure_transport"]
 
 
 @pytest.mark.asyncio
@@ -153,8 +156,9 @@ async def test_invalid_response_type(
         user=user,
     )
     response = await server.create_authorization_response(request)
-    assert response.status_code == HTTPStatus.BAD_REQUEST
-    assert response.content["error"] == "unsupported_response_type"
+    assert response.status_code == HTTPStatus.FOUND
+    query_params = parse_qs(urlparse(response.headers["Location"]).query)
+    assert query_params["error"] == ["unsupported_response_type"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_request_validator.py
+++ b/tests/test_request_validator.py
@@ -59,8 +59,8 @@ async def test_invalid_client_credentials(
     )
 
     response = await server.create_token_response(request)
-    assert response.status_code == HTTPStatus.BAD_REQUEST
-    assert response.content["error"] == "invalid_request"
+    assert response.status_code == HTTPStatus.UNAUTHORIZED
+    assert response.content["error"] == "invalid_client"
 
 
 @pytest.mark.asyncio

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -12,11 +12,11 @@ EMPTY_KEYS = {
         "client_id": Response(
             content=asdict(
                 ErrorResponse(
-                    error="invalid_request",
+                    error="invalid_client",
                     description="Missing client_id parameter.",
                 )
             ),
-            status_code=HTTPStatus.BAD_REQUEST,
+            status_code=HTTPStatus.UNAUTHORIZED,
             headers=default_headers,
         ),
         "response_type": Response(
@@ -159,11 +159,11 @@ INVALID_KEYS = {
         "client_id": Response(
             content=asdict(
                 ErrorResponse(
-                    error="invalid_request",
+                    error="invalid_client",
                     description="Invalid client_id parameter value.",
                 )
             ),
-            status_code=HTTPStatus.BAD_REQUEST,
+            status_code=HTTPStatus.UNAUTHORIZED,
             headers=default_headers,
         ),
         "response_type": Response(
@@ -261,21 +261,21 @@ INVALID_KEYS = {
         "client_id": Response(
             content=asdict(
                 ErrorResponse(
-                    error="invalid_request",
+                    error="invalid_client",
                     description="Invalid client_id parameter value.",
                 )
             ),
-            status_code=HTTPStatus.BAD_REQUEST,
+            status_code=HTTPStatus.UNAUTHORIZED,
             headers=default_headers,
         ),
         "client_secret": Response(
             content=asdict(
                 ErrorResponse(
-                    error="invalid_request",
+                    error="invalid_client",
                     description="Invalid client_id parameter value.",
                 )
             ),
-            status_code=HTTPStatus.BAD_REQUEST,
+            status_code=HTTPStatus.UNAUTHORIZED,
             headers=default_headers,
         ),
         "username": Response(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -20,14 +20,11 @@ EMPTY_KEYS = {
             headers=default_headers,
         ),
         "response_type": Response(
-            content=asdict(
-                ErrorResponse(
-                    error="invalid_request",
-                    description="Missing response_type parameter.",
-                )
+            content={},
+            status_code=HTTPStatus.FOUND,
+            headers=HTTPHeaderDict(
+                location="https://ownauth.com/callback?error=invalid_request&error_description=Missing%20response_type%20parameter."
             ),
-            status_code=HTTPStatus.BAD_REQUEST,
-            headers=default_headers,
         ),
         "redirect_uri": Response(
             content=asdict(
@@ -40,24 +37,18 @@ EMPTY_KEYS = {
             headers=default_headers,
         ),
         "code_challenge": Response(
-            content=asdict(
-                ErrorResponse(
-                    error="invalid_request",
-                    description="Code challenge required.",
-                )
+            content={},
+            status_code=HTTPStatus.FOUND,
+            headers=HTTPHeaderDict(
+                location="https://ownauth.com/callback?error=invalid_request&error_description=Code%20challenge%20required."
             ),
-            status_code=HTTPStatus.BAD_REQUEST,
-            headers=default_headers,
         ),
         "nonce": Response(
-            content=asdict(
-                ErrorResponse(
-                    error="invalid_request",
-                    description="Nonce required for response_type id_token.",
-                )
+            content={},
+            status_code=HTTPStatus.FOUND,
+            headers=HTTPHeaderDict(
+                location="https://ownauth.com/callback?error=invalid_request&error_description=Nonce%20required%20for%20response_type%20id_token."
             ),
-            status_code=HTTPStatus.BAD_REQUEST,
-            headers=default_headers,
         ),
     },
     "POST": {
@@ -167,14 +158,11 @@ INVALID_KEYS = {
             headers=default_headers,
         ),
         "response_type": Response(
-            content=asdict(
-                ErrorResponse(
-                    error="unsupported_response_type",
-                    description="",
-                )
+            content={},
+            status_code=HTTPStatus.FOUND,
+            headers=HTTPHeaderDict(
+                location="https://ownauth.com/callback?error=unsupported_response_type"
             ),
-            status_code=HTTPStatus.BAD_REQUEST,
-            headers=default_headers,
         ),
         "redirect_uri": Response(
             content=asdict(
@@ -187,24 +175,18 @@ INVALID_KEYS = {
             headers=default_headers,
         ),
         "code_challenge_method": Response(
-            content=asdict(
-                ErrorResponse(
-                    error="invalid_request",
-                    description="Transform algorithm not supported.",
-                )
+            content={},
+            status_code=HTTPStatus.FOUND,
+            headers=HTTPHeaderDict(
+                location="https://ownauth.com/callback?error=invalid_request&error_description=Transform%20algorithm%20not%20supported."
             ),
-            status_code=HTTPStatus.BAD_REQUEST,
-            headers=default_headers,
         ),
         "scope": Response(
-            content=asdict(
-                ErrorResponse(
-                    error="invalid_scope",
-                    description="",
-                )
+            content={},
+            status_code=HTTPStatus.FOUND,
+            headers=HTTPHeaderDict(
+                location="https://ownauth.com/callback?error=invalid_scope"
             ),
-            status_code=HTTPStatus.BAD_REQUEST,
-            headers=default_headers,
         ),
     },
     "POST": {


### PR DESCRIPTION
The spec defines that most errors to `/authorize` should be returned to the redirect URI with `error` and `error_description` query params:

    If the resource owner denies the access request or if the request
    fails for reasons other than a missing or invalid redirection URI,
    the authorization server informs the client by adding the following
    parameters to the query component of the redirection URI using the
    "application/x-www-form-urlencoded" format, per Appendix B:

Add `InvalidRedirectURIError` and use `InvalidClientError` for all `client_id` errors since these should not redirect. Update
`catch_errors_and_unavailability` to optionally return errors as redirects.