### PR TITLE
Exchanging an authorization code for an access token needs no client_secret

### DIFF
--- a/aioauth/grant_type.py
+++ b/aioauth/grant_type.py
@@ -27,7 +27,7 @@ from .utils import enforce_list, enforce_str, generate_token
 class GrantTypeBase(Generic[TRequest, TStorage]):
     """Base grant type that all other grant types inherit from."""
 
-    def __init__(self, storage: TStorage, client_id: str, client_secret: str):
+    def __init__(self, storage: TStorage, client_id: str, client_secret: Optional[str]):
         self.storage = storage
         self.client_id = client_id
         self.client_secret = client_secret
@@ -166,6 +166,10 @@ class PasswordGrantType(GrantTypeBase[TRequest, TStorage]):
     """
 
     async def validate_request(self, request: TRequest) -> Client:
+        # Password grant requires a client_secret
+        if self.client_secret is None:
+            raise InvalidClientError(request, "")
+
         client = await super().validate_request(request)
 
         if not request.post.username or not request.post.password:
@@ -254,3 +258,10 @@ class ClientCredentialsGrantType(GrantTypeBase[TRequest, TStorage]):
     access a user's resources.
     See `RFC 6749 section 4.4 <https://tools.ietf.org/html/rfc6749#section-4.4>`_.
     """
+
+    async def validate_request(self, request: TRequest) -> Client:
+        # client_credentials grant requires a client_secret
+        if self.client_secret is None:
+            raise InvalidClientError(request, "")
+
+        return await super().validate_request(request)

--- a/aioauth/grant_type.py
+++ b/aioauth/grant_type.py
@@ -168,7 +168,7 @@ class PasswordGrantType(GrantTypeBase[TRequest, TStorage]):
     async def validate_request(self, request: TRequest) -> Client:
         # Password grant requires a client_secret
         if self.client_secret is None:
-            raise InvalidClientError(request, "")
+            raise InvalidClientError[TRequest](request)
 
         client = await super().validate_request(request)
 
@@ -262,6 +262,6 @@ class ClientCredentialsGrantType(GrantTypeBase[TRequest, TStorage]):
     async def validate_request(self, request: TRequest) -> Client:
         # client_credentials grant requires a client_secret
         if self.client_secret is None:
-            raise InvalidClientError(request, "")
+            raise InvalidClientError[TRequest](request)
 
         return await super().validate_request(request)

--- a/aioauth/server.py
+++ b/aioauth/server.py
@@ -254,7 +254,15 @@ class AuthorizationServer(Generic[TRequest, TStorage]):
             response: An :py:class:`aioauth.responses.Response` object.
         """
         self.validate_request(request, ["POST"])
-        client_id, client_secret = self.get_client_credentials(request)
+
+        client_secret: Optional[str] = None
+        if request.post.grant_type in {"client_credentials", "password"}:
+            # client_secret is only expected for client_credentials, password grant types
+            # https://www.oauth.com/oauth2-servers/access-tokens/client-credentials/
+            # https://www.oauth.com/oauth2-servers/access-tokens/password-grant/
+            client_id, client_secret = self.get_client_credentials(request)
+        else:
+            client_id = request.post.client_id
 
         if not request.post.grant_type:
             # grant_type request value is empty

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -127,6 +127,8 @@ async def test_introspect_revoked_token(
     token = storage["tokens"][0]
 
     post = Post(
+        client_id=client_id,
+        client_secret=client_secret,
         grant_type="refresh_token",
         refresh_token=token.refresh_token,
     )
@@ -135,7 +137,6 @@ async def test_introspect_revoked_token(
         url=request_url,
         post=post,
         method="POST",
-        headers=encode_auth_headers(client_id, client_secret),
     )
     response = await server.create_token_response(request)
     assert response.status_code == HTTPStatus.OK

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -291,7 +291,6 @@ async def test_authorization_code_flow(server: AuthorizationServer, defaults: De
     query = dict(parse_qsl(location.query))
     code = query["code"]
 
-    print(f"client_id: {client_id}", flush=True)
     post = Post(
         client_id=client_id,
         code=code,

--- a/tests/test_request_validator.py
+++ b/tests/test_request_validator.py
@@ -198,16 +198,16 @@ async def test_expired_authorization_code(
         auth_time=(time.time() - settings.AUTHORIZATION_CODE_EXPIRES_IN),
     )
     post = Post(
+        client_id=defaults.client_id,
+        code=storage["authorization_codes"][0].code,
         grant_type="authorization_code",
         redirect_uri=defaults.redirect_uri,
-        code=storage["authorization_codes"][0].code,
     )
 
     request = Request(
         url=request_url,
         post=post,
         method="POST",
-        headers=encode_auth_headers(defaults.client_id, defaults.client_secret),
     )
     response = await server.create_token_response(request)
     assert response.status_code == HTTPStatus.BAD_REQUEST
@@ -228,6 +228,7 @@ async def test_expired_refresh_token(
     )
     request_url = "https://localhost"
     post = Post(
+        client_id=defaults.client_id,
         grant_type="refresh_token",
         refresh_token=refresh_token,
     )
@@ -235,7 +236,6 @@ async def test_expired_refresh_token(
         url=request_url,
         post=post,
         method="POST",
-        headers=encode_auth_headers(defaults.client_id, defaults.client_secret),
         settings=settings,
     )
     response = await server.create_token_response(request)


### PR DESCRIPTION
It could be that I'm doing something wrong, but if I attempt to exchange an authorization code for an access token and I don't supply some kind of dummy `client_secret`, then I get an `InvalidClientError`. If I supply a blank `client_secret`, I don't have a problem.

Relevant stacktrace is:
```
  File ".../aioauth/server.py", line 256, in create_token_response
    client_id, client_secret = self.get_client_credentials(request)
  File ".../aioauth/server.py", line 216, in get_client_credentials
    raise InvalidClientError[TRequest](
```

I think the code I've suggested solves the problem, badly, so I'm open to other ideas. I don't love that it hardcodes a check for `request.post.grant_type != "authorization_code"` because it doesn't solve the problem for other grant types and makes the library harder to extend with custom grant types, but that may not even be possible currently based on adjacent logic that has some strong opinions about the possible set of GrantTypes:

```python
GrantTypeClass: Type[
    Union[
        GrantTypeBase[TRequest, TStorage],
        AuthorizationCodeGrantType[TRequest, TStorage],
        PasswordGrantType[TRequest, TStorage],
        RefreshTokenGrantType[TRequest, TStorage],
        ClientCredentialsGrantType[TRequest, TStorage],
    ]
]
```

Which is all to say that maybe it's not a problem to hardcode a check of `request.post.grant_type != "authorization_code"`.

Thinking it over some more, I think this needs to be a bigger change because I think this only would fix the issue for the `authorization_code` grant type and it suggests that here are a some broken tests that need fixing. I'm happy to help with that, but would appreciate some confirmation that I'm not crazy first.