### PR TITLE
fix: type hinting refactoring and small bugfix

### DIFF
--- a/aioauth/errors.py
+++ b/aioauth/errors.py
@@ -56,7 +56,7 @@ class MethodNotAllowedError(OAuth2Error[TRequest]):
 
     description = "HTTP method is not allowed."
     status_code: HTTPStatus = HTTPStatus.METHOD_NOT_ALLOWED
-    error: Literal["method_is_not_allowed"] = "method_is_not_allowed"
+    error: ErrorType = "method_is_not_allowed"
 
 
 class InvalidRequestError(OAuth2Error[TRequest]):
@@ -82,7 +82,7 @@ class InvalidClientError(OAuth2Error[TRequest]):
     client.
     """
 
-    error: Literal["invalid_client"] = "invalid_client"
+    error: ErrorType = "invalid_client"
     status_code: HTTPStatus = HTTPStatus.UNAUTHORIZED
 
 
@@ -90,7 +90,7 @@ class InsecureTransportError(OAuth2Error[TRequest]):
     """An exception will be thrown if the current request is not secure."""
 
     description = "OAuth 2 MUST utilize https."
-    error: Literal["insecure_transport"] = "insecure_transport"
+    error: ErrorType = "insecure_transport"
 
 
 class UnsupportedGrantTypeError(OAuth2Error[TRequest]):
@@ -99,7 +99,7 @@ class UnsupportedGrantTypeError(OAuth2Error[TRequest]):
     server.
     """
 
-    error: Literal["unsupported_grant_type"] = "unsupported_grant_type"
+    error: ErrorType = "unsupported_grant_type"
 
 
 class UnsupportedResponseTypeError(OAuth2Error[TRequest]):
@@ -108,7 +108,7 @@ class UnsupportedResponseTypeError(OAuth2Error[TRequest]):
     code using this method.
     """
 
-    error: Literal["unsupported_response_type"] = "unsupported_response_type"
+    error: ErrorType = "unsupported_response_type"
 
 
 class InvalidGrantError(OAuth2Error[TRequest]):
@@ -121,7 +121,7 @@ class InvalidGrantError(OAuth2Error[TRequest]):
     See `RFC6749 section 5.2 <https://tools.ietf.org/html/rfc6749#section-5.2>`_.
     """
 
-    error: Literal["invalid_grant"] = "invalid_grant"
+    error: ErrorType = "invalid_grant"
 
 
 class MismatchingStateError(OAuth2Error[TRequest]):
@@ -137,7 +137,7 @@ class UnauthorizedClientError(OAuth2Error[TRequest]):
     grant type.
     """
 
-    error: Literal["unauthorized_client"] = "unauthorized_client"
+    error: ErrorType = "unauthorized_client"
 
 
 class InvalidScopeError(OAuth2Error[TRequest]):
@@ -148,7 +148,7 @@ class InvalidScopeError(OAuth2Error[TRequest]):
     See `RFC6749 section 5.2 <https://tools.ietf.org/html/rfc6749#section-5.2>`_.
     """
 
-    error: Literal["invalid_scope"] = "invalid_scope"
+    error: ErrorType = "invalid_scope"
 
 
 class ServerError(OAuth2Error[TRequest]):
@@ -159,7 +159,7 @@ class ServerError(OAuth2Error[TRequest]):
     to the client via a HTTP redirect.)
     """
 
-    error: Literal["temporarily_unavailable"] = "temporarily_unavailable"
+    error: ErrorType = "server_error"
 
 
 class TemporarilyUnavailableError(OAuth2Error[TRequest]):
@@ -170,7 +170,7 @@ class TemporarilyUnavailableError(OAuth2Error[TRequest]):
     status code cannot be returned to the client via a HTTP redirect.)
     """
 
-    error: Literal["temporarily_unavailable"] = "temporarily_unavailable"
+    error: ErrorType = "temporarily_unavailable"
 
 
 class InvalidRedirectURIError(OAuth2Error[TRequest]):
@@ -178,4 +178,4 @@ class InvalidRedirectURIError(OAuth2Error[TRequest]):
     The requested redirect URI is missing or not allowed.
     """
 
-    error: Literal["invalid_request"] = "invalid_request"
+    error: ErrorType = "invalid_request"

--- a/aioauth/grant_type.py
+++ b/aioauth/grant_type.py
@@ -148,7 +148,7 @@ class AuthorizationCodeGrantType(GrantTypeBase[TRequest, TStorage]):
         await self.storage.delete_authorization_code(
             request,
             client.client_id,
-            request.post.code,  # type: ignore
+            request.post.code,
         )
 
         return token_response

--- a/aioauth/response_type.py
+++ b/aioauth/response_type.py
@@ -8,7 +8,7 @@ Response objects used throughout the project.
 ----
 """
 
-from typing import Generic, List
+from typing import Generic, get_args, Tuple
 from .utils import generate_token
 from .errors import (
     InvalidClientError,
@@ -36,7 +36,9 @@ class ResponseTypeBase(Generic[TRequest, TStorage]):
         self.storage = storage
 
     async def validate_request(self, request: TRequest) -> Client:
-        code_challenge_methods: List[CodeChallengeMethod] = ["plain", "S256"]
+        code_challenge_methods: Tuple[CodeChallengeMethod, ...] = get_args(
+            CodeChallengeMethod
+        )
 
         if not request.query.client_id:
             raise InvalidClientError[TRequest](

--- a/aioauth/response_type.py
+++ b/aioauth/response_type.py
@@ -7,8 +7,14 @@ Response objects used throughout the project.
 
 ----
 """
+import sys
+from typing import Generic, Tuple
 
-from typing import Generic, get_args, Tuple
+if sys.version_info >= (3, 8):
+    from typing import get_args
+else:
+    from typing_extensions import get_args
+
 from .utils import generate_token
 from .errors import (
     InvalidClientError,

--- a/aioauth/server.py
+++ b/aioauth/server.py
@@ -18,7 +18,7 @@ Warning:
 """
 from dataclasses import asdict
 from http import HTTPStatus
-from typing import Any, Dict, Generic, List, Optional, Set, Tuple, Type, Union
+from typing import Any, Dict, Generic, List, Optional, Tuple, Type, Union, get_args
 
 from .collections import HTTPHeaderDict
 from .constances import default_headers
@@ -161,7 +161,7 @@ class AuthorizationServer(Generic[TRequest, TStorage]):
         self.validate_request(request, ["POST"])
         client_id, _ = self.get_client_credentials(request)
 
-        token_types: Set[TokenType] = {"access_token", "refresh_token"}
+        token_types: Tuple[TokenType, ...] = get_args(TokenType)
         token_type: TokenType = "refresh_token"
 
         access_token = None

--- a/aioauth/server.py
+++ b/aioauth/server.py
@@ -16,9 +16,16 @@ Warning:
 
 ----
 """
+import sys
 from dataclasses import asdict
 from http import HTTPStatus
-from typing import Any, Dict, Generic, List, Optional, Tuple, Type, Union, get_args
+from typing import Any, Dict, Generic, List, Optional, Tuple, Type, Union
+
+
+if sys.version_info >= (3, 8):
+    from typing import get_args
+else:
+    from typing_extensions import get_args
 
 from .collections import HTTPHeaderDict
 from .constances import default_headers

--- a/aioauth/types.py
+++ b/aioauth/types.py
@@ -7,7 +7,12 @@ Containers that contain constants used throughout the project.
 
 ----
 """
-from typing_extensions import Literal
+import sys
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 
 ErrorType = Literal[


### PR DESCRIPTION
For `ServerError` class the `ErrorType` value was `temporarily_unavailable`, it was replaced with `server_error` value.

Each attribute of error classes now has `ErrorType` type.

For `Literal`'s using the `get_args` in order to get the literal's value instead of hard coded strings.