### PR TITLE
A client_secret is not required for the password grant type

### DIFF
--- a/aioauth/errors.py
+++ b/aioauth/errors.py
@@ -93,11 +93,11 @@ class InvalidClientError(OAuth2Error[TRequest]):
     ):
         super().__init__(request, description, headers or HTTPHeaderDict())
 
-        auth_values = ["error={}".format(self.error)]
+        auth_values = [f"error={self.error}"]
         if self.description:
-            auth_values.append("error_description={}".format(self.description))
+            auth_values.append(f"error_description={self.description}")
         if self.error_uri:
-            auth_values.append("error_uri={}".format(self.error_uri))
+            auth_values.append(f"error_uri={self.error_uri}")
         self.headers["WWW-Authenticate"] = "Basic " + ", ".join(auth_values)
 
 

--- a/aioauth/errors.py
+++ b/aioauth/errors.py
@@ -85,6 +85,21 @@ class InvalidClientError(OAuth2Error[TRequest]):
     error: ErrorType = "invalid_client"
     status_code: HTTPStatus = HTTPStatus.UNAUTHORIZED
 
+    def __init__(
+        self,
+        request: TRequest,
+        description: Optional[str] = None,
+        headers: Optional[HTTPHeaderDict] = None,
+    ):
+        super().__init__(request, description, headers or HTTPHeaderDict())
+
+        auth_values = ["error={}".format(self.error)]
+        if self.description:
+            auth_values.append("error_description={}".format(self.description))
+        if self.error_uri:
+            auth_values.append("error_uri={}".format(self.error_uri))
+        self.headers["WWW-Authenticate"] = "Basic " + ", ".join(auth_values)
+
 
 class InsecureTransportError(OAuth2Error[TRequest]):
     """An exception will be thrown if the current request is not secure."""

--- a/aioauth/grant_type.py
+++ b/aioauth/grant_type.py
@@ -166,10 +166,6 @@ class PasswordGrantType(GrantTypeBase[TRequest, TStorage]):
     """
 
     async def validate_request(self, request: TRequest) -> Client:
-        # Password grant requires a client_secret
-        if self.client_secret is None:
-            raise InvalidClientError[TRequest](request)
-
         client = await super().validate_request(request)
 
         if not request.post.username or not request.post.password:

--- a/aioauth/server.py
+++ b/aioauth/server.py
@@ -215,14 +215,14 @@ class AuthorizationServer(Generic[TRequest, TStorage]):
 
         if client_id is None or client_secret is None:
             authorization = request.headers.get("Authorization", "")
-            headers = HTTPHeaderDict({"WWW-Authenticate": "Basic"})
 
             # Get client credentials from the Authorization header.
             try:
                 client_id, client_secret = decode_auth_headers(authorization)
             except ValueError as exc:
                 raise InvalidClientError[TRequest](
-                    request=request, headers=headers
+                    description="Invalid client_id parameter value.",
+                    request=request,
                 ) from exc
 
         return client_id, client_secret

--- a/aioauth/server.py
+++ b/aioauth/server.py
@@ -273,6 +273,8 @@ class AuthorizationServer(Generic[TRequest, TStorage]):
             # https://www.oauth.com/oauth2-servers/access-tokens/password-grant/
             try:
                 client_id, client_secret = self.get_client_credentials(request)
+                # Prefer client_secret to be None rather than a blank string
+                client_secret = client_secret or None
             except InvalidClientError as exc:
                 # When InvalidClientError is raised here it probably means that
                 # client_secret could not be found and the basic auth header

--- a/aioauth/server.py
+++ b/aioauth/server.py
@@ -263,11 +263,24 @@ class AuthorizationServer(Generic[TRequest, TStorage]):
         self.validate_request(request, ["POST"])
 
         client_secret: Optional[str] = None
-        if request.post.grant_type in {"client_credentials", "password"}:
-            # client_secret is only expected for client_credentials, password grant types
+
+        if request.post.grant_type == "client_credentials":
+            # client_secret is required for the client_credentials grant type
             # https://www.oauth.com/oauth2-servers/access-tokens/client-credentials/
-            # https://www.oauth.com/oauth2-servers/access-tokens/password-grant/
             client_id, client_secret = self.get_client_credentials(request)
+        elif request.post.grant_type == "password":
+            # client_secret is optional for the password grant type
+            # https://www.oauth.com/oauth2-servers/access-tokens/password-grant/
+            try:
+                client_id, client_secret = self.get_client_credentials(request)
+            except InvalidClientError as exc:
+                # When InvalidClientError is raised here it probably means that
+                # client_secret could not be found and the basic auth header
+                # had no useful data. client_secret is optional for the password
+                # grant type, so make sure we have a client_id and try to proceed.
+                client_id = request.post.client_id
+                if not client_id:
+                    raise exc
         else:
             client_id = request.post.client_id
 

--- a/aioauth/utils.py
+++ b/aioauth/utils.py
@@ -178,7 +178,7 @@ def encode_auth_headers(client_id: str, client_secret: str) -> HTTPHeaderDict:
 
 def decode_auth_headers(authorization: str) -> Tuple[str, str]:
     """
-    Decodes an encrypted HTTP basic authentication string.
+    Decodes an encoded HTTP basic authentication string.
     Returns a tuple of the form ``(client_id, client_secret)``, and
     raises a :py:class:`aioauth.errors.InvalidClientError` exception if nothing
     could be decoded.

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -288,6 +288,31 @@ async def test_password_grant_type_without_client_secret(
 
 
 @pytest.mark.asyncio
+async def test_password_grant_type_without_client_secret_using_basic_auth(
+    server: AuthorizationServer, defaults: Defaults
+):
+    client_id = defaults.client_id
+    request_url = "https://localhost"
+
+    post = Post(
+        grant_type="password",
+        username=defaults.username,
+        password=defaults.password,
+    )
+
+    request = Request(
+        post=post,
+        url=request_url,
+        method="POST",
+        headers=encode_auth_headers(client_id, ""),
+    )
+
+    await check_request_validators(request, server.create_token_response)
+    response = await server.create_token_response(request)
+    assert response.status_code == HTTPStatus.OK
+
+
+@pytest.mark.asyncio
 async def test_authorization_code_flow(server: AuthorizationServer, defaults: Defaults):
     client_id = defaults.client_id
     request_url = "https://localhost"

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -237,7 +237,9 @@ async def test_implicit_flow(server: AuthorizationServer, defaults: Defaults):
 
 
 @pytest.mark.asyncio
-async def test_password_grant_type(server: AuthorizationServer, defaults: Defaults):
+async def test_password_grant_type_with_client_secret(
+    server: AuthorizationServer, defaults: Defaults
+):
     client_id = defaults.client_id
     client_secret = defaults.client_secret
     request_url = "https://localhost"
@@ -253,6 +255,31 @@ async def test_password_grant_type(server: AuthorizationServer, defaults: Defaul
         url=request_url,
         method="POST",
         headers=encode_auth_headers(client_id, client_secret),
+    )
+
+    await check_request_validators(request, server.create_token_response)
+    response = await server.create_token_response(request)
+    assert response.status_code == HTTPStatus.OK
+
+
+@pytest.mark.asyncio
+async def test_password_grant_type_without_client_secret(
+    server: AuthorizationServer, defaults: Defaults
+):
+    client_id = defaults.client_id
+    request_url = "https://localhost"
+
+    post = Post(
+        client_id=client_id,
+        grant_type="password",
+        username=defaults.username,
+        password=defaults.password,
+    )
+
+    request = Request(
+        post=post,
+        url=request_url,
+        method="POST",
     )
 
     await check_request_validators(request, server.create_token_response)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -17,7 +17,13 @@ EMPTY_KEYS = {
                 )
             ),
             status_code=HTTPStatus.UNAUTHORIZED,
-            headers=default_headers,
+            headers=HTTPHeaderDict(
+                {
+                    "www-authenticate": (
+                        "Basic error=invalid_client, error_description=Missing client_id parameter."
+                    )
+                }
+            ),
         ),
         "response_type": Response(
             content={},
@@ -110,6 +116,13 @@ EMPTY_KEYS = {
                 )
             ),
             status_code=HTTPStatus.UNAUTHORIZED,
+            headers=HTTPHeaderDict(
+                {
+                    "www-authenticate": (
+                        "Basic error=invalid_client, error_description=Invalid client_id parameter value."
+                    )
+                }
+            ),
         ),
         "username": Response(
             content=asdict(
@@ -144,7 +157,13 @@ INVALID_KEYS = {
                 )
             ),
             status_code=HTTPStatus.UNAUTHORIZED,
-            headers=default_headers,
+            headers=HTTPHeaderDict(
+                {
+                    "www-authenticate": (
+                        "Basic error=invalid_client, error_description=Invalid client_id parameter value."
+                    )
+                }
+            ),
         ),
         "response_type": Response(
             content={},
@@ -237,7 +256,13 @@ INVALID_KEYS = {
                 )
             ),
             status_code=HTTPStatus.UNAUTHORIZED,
-            headers=default_headers,
+            headers=HTTPHeaderDict(
+                {
+                    "www-authenticate": (
+                        "Basic error=invalid_client, error_description=Invalid client_id parameter value."
+                    )
+                }
+            ),
         ),
         "username": Response(
             content=asdict(
@@ -304,30 +329,7 @@ async def check_request_validators(
     if request.method == "GET":
         query_dict = get_keys(request.query)
 
-    # Make a copy of the responses dict because we may override some values
-    responses = dict(EMPTY_KEYS[request.method])
-
-    # client_credentials and password grant types may include credentials in
-    # headers, so the expected error response needs to be overriden for those
-    # grant types.
-    if query_dict.get("grant_type") in {"client_credentials", "password"}:
-        if request.method == "GET":
-            headers = default_headers
-        else:
-            headers = HTTPHeaderDict({"www-authenticate": "Basic"})
-        invalid_client_response = Response(
-            content=asdict(
-                ErrorResponse(
-                    error="invalid_client",
-                    description="",
-                )
-            ),
-            status_code=HTTPStatus.UNAUTHORIZED,
-            headers=headers,
-        )
-        responses["client_id"] = invalid_client_response
-        responses["client_secret"] = invalid_client_response
-
+    responses = EMPTY_KEYS[request.method]
     await check_query_values(request, responses, query_dict, endpoint_func, None)
 
     responses = INVALID_KEYS[request.method]


### PR DESCRIPTION
Believe it or not, this is the beginning of working to make it so the password grant doesn't require a `client_secret`.

In broad strokes, this aims to make the setting of the `WWW-Authenticate` header the responsibility of the `InvalidClientError` instead of being the responsibility of the `get_client_credentials` function.

EDIT: I was going to make `client_secret` optional for the password grant in another PR, but it doesn't seem like there's enough extra code required to warrant that. So this now includes logic to make it so the password grant type doesn't require a `client_secret`. Viewing the changes by commit may help disentangle things.