### PR TITLE
A client must use their client_secret if they have one

### DIFF
--- a/aioauth/server.py
+++ b/aioauth/server.py
@@ -273,14 +273,15 @@ class AuthorizationServer(Generic[TRequest, TStorage]):
             # https://www.oauth.com/oauth2-servers/access-tokens/password-grant/
             try:
                 client_id, client_secret = self.get_client_credentials(request)
-                # Prefer client_secret to be None rather than a blank string
-                client_secret = client_secret or None
             except InvalidClientError as exc:
                 # When InvalidClientError is raised here it probably means that
                 # client_secret could not be found and the basic auth header
                 # had no useful data. client_secret is optional for the password
                 # grant type, so make sure we have a client_id and try to proceed.
                 client_id = request.post.client_id
+                # client_secret must not be None. When client_secret is None,
+                # storage.get_client will not run standard checks on the client_secret
+                client_secret = request.post.client_secret or ""
                 if not client_id:
                     raise exc
         else:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    override_defaults: override default test values for duration of the given scope

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,17 +26,30 @@ from .models import Defaults
 
 
 @pytest.fixture
-def defaults() -> Defaults:
-    return Defaults(
-        client_id=generate_token(48),
-        client_secret=generate_token(48),
-        code=generate_token(5),
-        refresh_token=generate_token(48),
-        access_token=generate_token(42),
-        username="root",
-        password="toor",
-        redirect_uri="https://ownauth.com/callback",
-        scope="read write",
+def defaults(request) -> Defaults:
+    marker = request.node.get_closest_marker("override_defaults")
+    kwargs = marker.kwargs if marker else {}
+
+    access_token: str = kwargs.get("access_token", generate_token(42))
+    client_id: str = kwargs.get("client_id", generate_token(48))
+    client_secret: str = kwargs.get("client_secret", generate_token(48))
+    code: str = kwargs.get("code", generate_token(5))
+    password: str = kwargs.get("password", "toor")
+    redirect_uri: str = kwargs.get("redirect_uri", "https://ownauth.com/callback")
+    refresh_token: str = kwargs.get("refresh_token", generate_token(48))
+    scope: str = kwargs.get("scope", "scope")
+    username: str = kwargs.get("username", "root")
+
+    yield Defaults(
+        client_id=client_id,
+        client_secret=client_secret,
+        code=code,
+        refresh_token=refresh_token,
+        access_token=access_token,
+        username=username,
+        password=password,
+        redirect_uri=redirect_uri,
+        scope=scope,
     )
 
 

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -263,6 +263,7 @@ async def test_password_grant_type_with_client_secret(
 
 
 @pytest.mark.asyncio
+@pytest.mark.override_defaults(client_secret="")
 async def test_password_grant_type_without_client_secret(
     server: AuthorizationServer, defaults: Defaults
 ):
@@ -288,6 +289,7 @@ async def test_password_grant_type_without_client_secret(
 
 
 @pytest.mark.asyncio
+@pytest.mark.override_defaults(client_secret="")
 async def test_password_grant_type_without_client_secret_using_basic_auth(
     server: AuthorizationServer, defaults: Defaults
 ):


### PR DESCRIPTION
I realized that some of the tests I'd changed/added should have failed when a client with a client_secret tried to use the password grant without their client_secret. This fixes the related bug and the tests that should have been broken.

Not sure if there's an easier way to build a server with custom settings, but I thought this approach was pretty clean.