### PR TITLE
Fix bug preventing some grant types from getting client_secret

### DIFF
--- a/aioauth/server.py
+++ b/aioauth/server.py
@@ -268,9 +268,8 @@ class AuthorizationServer(Generic[TRequest, TStorage]):
             # client_secret is required for the client_credentials grant type
             # https://www.oauth.com/oauth2-servers/access-tokens/client-credentials/
             client_id, client_secret = self.get_client_credentials(request)
-        elif request.post.grant_type == "password":
-            # client_secret is optional for the password grant type
-            # https://www.oauth.com/oauth2-servers/access-tokens/password-grant/
+        else:
+            # for other grant types, client_secret is required if the client has one.
             try:
                 client_id, client_secret = self.get_client_credentials(request)
             except InvalidClientError as exc:
@@ -284,8 +283,6 @@ class AuthorizationServer(Generic[TRequest, TStorage]):
                 client_secret = request.post.client_secret or ""
                 if not client_id:
                     raise exc
-        else:
-            client_id = request.post.client_id
 
         if not request.post.grant_type:
             # grant_type request value is empty

--- a/aioauth/server.py
+++ b/aioauth/server.py
@@ -269,7 +269,11 @@ class AuthorizationServer(Generic[TRequest, TStorage]):
             # https://www.oauth.com/oauth2-servers/access-tokens/client-credentials/
             client_id, client_secret = self.get_client_credentials(request)
         else:
-            # for other grant types, client_secret is required if the client has one.
+            # for other grant types, client_secret is required if the client has one:
+            # If the client type is confidential or the client was issued client credentials
+            # (or assigned other authentication requirements), the client MUST authenticate
+            # with the authorization server as described in Section 3.2.1.
+            # https://www.rfc-editor.org/rfc/rfc6749#section-4.1.3
             try:
                 client_id, client_secret = self.get_client_credentials(request)
             except InvalidClientError as exc:

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -19,6 +19,7 @@ from .utils import check_request_validators
 
 
 @pytest.mark.asyncio
+@pytest.mark.override_defaults(client_secret="")
 async def test_authorization_code_flow_plain_code_challenge(
     server: AuthorizationServer, defaults: Defaults, db: BaseStorage
 ):
@@ -138,6 +139,7 @@ async def test_authorization_code_flow_plain_code_challenge(
 
 
 @pytest.mark.asyncio
+@pytest.mark.override_defaults(client_secret="")
 async def test_authorization_code_flow_pkce_code_challenge(
     server: AuthorizationServer, defaults: Defaults, db: BaseStorage
 ):
@@ -315,6 +317,7 @@ async def test_password_grant_type_without_client_secret_using_basic_auth(
 
 
 @pytest.mark.asyncio
+@pytest.mark.override_defaults(client_secret="")
 async def test_authorization_code_flow(server: AuthorizationServer, defaults: Defaults):
     client_id = defaults.client_id
     request_url = "https://localhost"
@@ -365,6 +368,7 @@ async def test_authorization_code_flow(server: AuthorizationServer, defaults: De
 
 
 @pytest.mark.asyncio
+@pytest.mark.override_defaults(client_secret="")
 async def test_authorization_code_flow_credentials_in_post(
     server: AuthorizationServer, defaults: Defaults
 ):

--- a/tests/test_request_validator.py
+++ b/tests/test_request_validator.py
@@ -184,6 +184,7 @@ async def test_anonymous_user(server: AuthorizationServer, defaults: Defaults, s
 
 
 @pytest.mark.asyncio
+@pytest.mark.override_defaults(client_secret="")
 async def test_expired_authorization_code(
     server: AuthorizationServer,
     defaults: Defaults,
@@ -215,6 +216,7 @@ async def test_expired_authorization_code(
 
 
 @pytest.mark.asyncio
+@pytest.mark.override_defaults(client_secret="")
 async def test_expired_refresh_token(
     server: AuthorizationServer,
     defaults: Defaults,


### PR DESCRIPTION
I believe this should fix https://github.com/aliev/aioauth/issues/81.

Not sure how I messed this one up. The spec is pretty clear that, regardless of grant type, a client with a secret must authenticate with the secret:
> If the client type is confidential or the client was issued client credentials (or assigned other authentication requirements), the client MUST authenticate with the authorization server as described in Section 3.2.1.

Disclaimer: I just fixed existing tests to pass. I didn't add new tests that are needed. There's a bunch of refactoring I want to do to make it possible to test different `client_secret` scenarios cleanly without repeating a lot of code. I started that [over here](https://github.com/aliev/aioauth/commit/133d77389fd56379deac91e7b95bb900069e7ac4), but still have more to do. I will get to the tests, but wanted to get this fix in place sooner.