### PR TITLE
fix: return correct `toke_type` in introspection

### DIFF
--- a/aioauth/server.py
+++ b/aioauth/server.py
@@ -199,7 +199,7 @@ class AuthorizationServer(Generic[TRequest, TStorage]):
                 scope=token.scope,
                 client_id=token.client_id,
                 expires_in=token.expires_in,
-                token_type=token_type,
+                token_type=token.token_type,
             )
         else:
             token_response = TokenInactiveIntrospectionResponse()


### PR DESCRIPTION
The introspection response currently returns as `token_type` the value of the `token_type_hint` parameter (defaulted to "refresh_token"). However, [RFC7662, Section 2.2](https://www.rfc-editor.org/rfc/rfc7662#section-2.2) prescribes this to be the same kind of `token_type` as in the responses from the token endpoint (which is `"Bearer"` by default), which is the one stored as part of the token's `TToken` instance.