### PR TITLE
Add state parameter to authorization error redirects

### DIFF
--- a/aioauth/errors.py
+++ b/aioauth/errors.py
@@ -27,12 +27,14 @@ class OAuth2Error(Exception, Generic[TRequest]):
     status_code: HTTPStatus = HTTPStatus.BAD_REQUEST
     error_uri: str = ""
     headers: HTTPHeaderDict = default_headers
+    state: str = ""
 
     def __init__(
         self,
         request: TRequest,
         description: Optional[str] = None,
         headers: Optional[HTTPHeaderDict] = None,
+        state: Optional[str] = None,
     ):
         self.request = request
 
@@ -41,6 +43,9 @@ class OAuth2Error(Exception, Generic[TRequest]):
 
         if headers is not None:
             self.headers = headers
+
+        if state is not None:
+            self.state = state
 
         if request.settings.ERROR_URI:
             self.error_uri = urljoin(request.settings.ERROR_URI, self.error)
@@ -90,9 +95,10 @@ class InvalidClientError(OAuth2Error[TRequest]):
         request: TRequest,
         description: Optional[str] = None,
         headers: Optional[HTTPHeaderDict] = None,
+        state: Optional[str] = None,
     ):
         super().__init__(
-            request, description, headers or HTTPHeaderDict(default_headers)
+            request, description, headers or HTTPHeaderDict(default_headers), state
         )
 
         auth_values = [f"error={self.error}"]

--- a/aioauth/server.py
+++ b/aioauth/server.py
@@ -382,13 +382,17 @@ class AuthorizationServer(Generic[TRequest, TStorage]):
         # Response content
         content = {}
 
+        state = request.query.state
+
         if not response_type_list:
             raise InvalidRequestError[TRequest](
-                request=request, description="Missing response_type parameter."
+                request=request,
+                description="Missing response_type parameter.",
+                state=state,
             )
 
-        if request.query.state:
-            responses["state"] = request.query.state
+        if state:
+            responses["state"] = state
 
         for response_type in response_type_list:
             ResponseTypeClass = self.response_types.get(response_type)
@@ -396,7 +400,7 @@ class AuthorizationServer(Generic[TRequest, TStorage]):
                 response_type_classes.add(ResponseTypeClass)
 
         if not response_type_classes:
-            raise UnsupportedResponseTypeError(request=request)
+            raise UnsupportedResponseTypeError(request=request, state=state)
 
         for ResponseTypeClass in response_type_classes:
             response_type = ResponseTypeClass(storage=self.storage)

--- a/aioauth/utils.py
+++ b/aioauth/utils.py
@@ -261,6 +261,8 @@ def catch_errors_and_unavailability(
                     query["error_description"] = exc.description
                 if request.settings.ERROR_URI:
                     query["error_uri"] = request.settings.ERROR_URI
+                if exc.state:
+                    query["state"] = exc.state
                 location = build_uri(request.query.redirect_uri, query)
                 return Response(
                     status_code=HTTPStatus.FOUND,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -314,6 +314,17 @@ async def check_query_values(
             request_ = replace(request_, query=query)
 
         response_expected = responses[key]
+
+        if (
+            request_.method == "GET"
+            and request_.query.state
+            and response_expected.status_code == HTTPStatus.FOUND
+        ):
+            # error redirects should include the state parameter
+            headers = HTTPHeaderDict(**response_expected.headers)
+            headers["location"] += f"&state={request_.query.state}"
+            response_expected = replace(response_expected, headers=headers)
+
         response_actual = await endpoint_func(request_)
 
         assert (


### PR DESCRIPTION
The spec states that when redirecting back to the client after an authorization request error, the state parameter should be included if it was present in the request:

>   state
>         REQUIRED if a "state" parameter was present in the client
>         authorization request.  The exact value received from the
>         client.

https://www.rfc-editor.org/rfc/rfc6749.html#section-4.1.2.1

This adds the state parameter to redirect responses for authorization request errors. Additionally this modifies the `check_query_values` test utility function to inject the state into the expected redirect URI, so that the behaviour is tested.

Before the change:

```
FAILED tests/test_flow.py::test_authorization_code_flow - AssertionError: Response(content={}, status_code=<HTTPStatus.FOUND: 302>, headers={'location': 'https://ownauth.com/callback?error=invalid_request&error_description=Missing%20response_type%20parameter.&state=fs0DxDPJbC'}) != Response(content={}, status_code...
FAILED tests/test_flow.py::test_authorization_code_flow_credentials_in_post - AssertionError: Response(content={}, status_code=<HTTPStatus.FOUND: 302>, headers={'location': 'https://ownauth.com/callback?error=invalid_request&error_description=Missing%20response_type%20parameter.&state=LJ8oByKgl0'}) != Response(con...
FAILED tests/test_flow.py::test_multiple_response_types - AssertionError: Response(content={}, status_code=<HTTPStatus.FOUND: 302>, headers={'location': 'https://ownauth.com/callback?error=invalid_request&error_description=Missing%20response_type%20parameter.&state=Up4ghYWkwM'}) != Response(content={}, status_code...
FAILED tests/test_flow.py::test_response_type_none - AssertionError: Response(content={}, status_code=<HTTPStatus.FOUND: 302>, headers={'location': 'https://ownauth.com/callback?error=invalid_request&error_description=Missing%20response_type%20parameter.&state=sxQqEiMdU3'}) != Response(content={}, status_code=<HTT...
FAILED tests/test_flow.py::test_response_type_id_token[query] - AssertionError: Response(content={}, status_code=<HTTPStatus.FOUND: 302>, headers={'location': 'https://ownauth.com/callback?error=invalid_request&error_description=Missing%20response_type%20parameter.&state=4k3ccmIZEJ'}) != Response(content={}, statu...
FAILED tests/test_flow.py::test_response_type_id_token[form_post] - AssertionError: Response(content={}, status_code=<HTTPStatus.FOUND: 302>, headers={'location': 'https://ownauth.com/callback?error=invalid_request&error_description=Missing%20response_type%20parameter.&state=9vdYmr2n1o'}) != Response(content={}, s...
FAILED tests/test_flow.py::test_response_type_id_token[fragment] - AssertionError: Response(content={}, status_code=<HTTPStatus.FOUND: 302>, headers={'location': 'https://ownauth.com/callback?error=invalid_request&error_description=Missing%20response_type%20parameter.&state=hxiKrAuT9z'}) != Response(content={}, st...
FAILED tests/test_flow.py::test_response_type_id_token[None] - AssertionError: Response(content={}, status_code=<HTTPStatus.FOUND: 302>, headers={'location': 'https://ownauth.com/callback?error=invalid_request&error_description=Missing%20response_type%20parameter.&state=t4CM6WShmm'}) != Response(content={}, status...
FAILED tests/oidc/core/test_flow.py::test_authorization_endpoint_allows_prompt_query_param[username-HTTPStatus.FOUND] - AssertionError: Response(content={}, status_code=<HTTPStatus.FOUND: 302>, headers={'location': 'https://ownauth.com/callback?error=invalid_request&error_description=Missing%20response_type%20para...
FAILED tests/oidc/core/test_flow.py::test_authorization_endpoint_allows_prompt_query_param[None-HTTPStatus.UNAUTHORIZED] - AssertionError: Response(content={}, status_code=<HTTPStatus.FOUND: 302>, headers={'location': 'https://ownauth.com/callback?error=invalid_request&error_description=Missing%20response_type%20p...

Results (0.85s):
      33 passed
      10 failed
         - tests/test_flow.py:342 test_authorization_code_flow
         - tests/test_flow.py:400 test_authorization_code_flow_credentials_in_post
         - tests/test_flow.py:502 test_multiple_response_types
         - tests/test_flow.py:543 test_response_type_none
         - tests/test_flow.py:578 test_response_type_id_token[query]
         - tests/test_flow.py:578 test_response_type_id_token[form_post]
         - tests/test_flow.py:578 test_response_type_id_token[fragment]
         - tests/test_flow.py:578 test_response_type_id_token[None]
         - tests/oidc/core/test_flow.py:14 test_authorization_endpoint_allows_prompt_query_param[username-HTTPStatus.FOUND]
         - tests/oidc/core/test_flow.py:14 test_authorization_endpoint_allows_prompt_query_param[None-HTTPStatus.UNAUTHORIZED]
```

After the change:

```
Results (0.70s):
      43 passed
```

I think the way I implemented the tests for this change is a little bit hackish. Let me know what you think and if you have any better ideas how it could be implemented. Thanks, Shawn