### PR TITLE
Make User generic in OIDC Request class

### DIFF
--- a/aioauth/errors.py
+++ b/aioauth/errors.py
@@ -27,12 +27,14 @@ class OAuth2Error(Exception, Generic[TRequest]):
     status_code: HTTPStatus = HTTPStatus.BAD_REQUEST
     error_uri: str = ""
     headers: HTTPHeaderDict = default_headers
+    state: str = ""
 
     def __init__(
         self,
         request: TRequest,
         description: Optional[str] = None,
         headers: Optional[HTTPHeaderDict] = None,
+        state: Optional[str] = None,
     ):
         self.request = request
 
@@ -41,6 +43,9 @@ class OAuth2Error(Exception, Generic[TRequest]):
 
         if headers is not None:
             self.headers = headers
+
+        if state is not None:
+            self.state = state
 
         if request.settings.ERROR_URI:
             self.error_uri = urljoin(request.settings.ERROR_URI, self.error)
@@ -90,9 +95,10 @@ class InvalidClientError(OAuth2Error[TRequest]):
         request: TRequest,
         description: Optional[str] = None,
         headers: Optional[HTTPHeaderDict] = None,
+        state: Optional[str] = None,
     ):
         super().__init__(
-            request, description, headers or HTTPHeaderDict(default_headers)
+            request, description, headers or HTTPHeaderDict(default_headers), state
         )
 
         auth_values = [f"error={self.error}"]

--- a/aioauth/oidc/core/requests.py
+++ b/aioauth/oidc/core/requests.py
@@ -2,11 +2,17 @@ from dataclasses import dataclass, field
 
 from typing import Any, Optional, TypeVar
 
-from aioauth.requests import BaseRequest, Query as BaseQuery, Post
+from aioauth.requests import (
+    BaseRequest as BaseOAuth2Request,
+    Query as OAuth2Query,
+    Post,
+    TPost,
+    TUser,
+)
 
 
 @dataclass
-class Query(BaseQuery):
+class Query(OAuth2Query):
     # Space delimited, case sensitive list of ASCII string values that
     # specifies whether the Authorization Server prompts the End-User for
     # reauthentication and consent. The defined values are: none, login,
@@ -15,17 +21,29 @@ class Query(BaseQuery):
     prompt: Optional[str] = None
 
 
+TQuery = TypeVar("TQuery", bound=Query)
+
+
 @dataclass
-class Request(BaseRequest[Query, Post, Any]):
+class BaseRequest(BaseOAuth2Request[TQuery, TPost, TUser]):
     """
     Object that contains a client's complete request with extensions as defined
     by OpenID Core.
     https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest
     """
 
+    query: TQuery
+    post: TPost
+    user: Optional[TUser] = None
+
+
+TRequest = TypeVar("TRequest", bound=BaseRequest)
+
+
+@dataclass
+class Request(BaseRequest[Query, Post, Any]):
+    """Object that contains a client's complete request."""
+
     query: Query = field(default_factory=Query)
     post: Post = field(default_factory=Post)
     user: Optional[Any] = None
-
-
-TRequest = TypeVar("TRequest", bound=Request)

--- a/aioauth/server.py
+++ b/aioauth/server.py
@@ -382,13 +382,17 @@ class AuthorizationServer(Generic[TRequest, TStorage]):
         # Response content
         content = {}
 
+        state = request.query.state
+
         if not response_type_list:
             raise InvalidRequestError[TRequest](
-                request=request, description="Missing response_type parameter."
+                request=request,
+                description="Missing response_type parameter.",
+                state=state,
             )
 
-        if request.query.state:
-            responses["state"] = request.query.state
+        if state:
+            responses["state"] = state
 
         for response_type in response_type_list:
             ResponseTypeClass = self.response_types.get(response_type)
@@ -396,7 +400,7 @@ class AuthorizationServer(Generic[TRequest, TStorage]):
                 response_type_classes.add(ResponseTypeClass)
 
         if not response_type_classes:
-            raise UnsupportedResponseTypeError(request=request)
+            raise UnsupportedResponseTypeError(request=request, state=state)
 
         for ResponseTypeClass in response_type_classes:
             response_type = ResponseTypeClass(storage=self.storage)

--- a/aioauth/utils.py
+++ b/aioauth/utils.py
@@ -261,6 +261,8 @@ def catch_errors_and_unavailability(
                     query["error_description"] = exc.description
                 if request.settings.ERROR_URI:
                     query["error_uri"] = request.settings.ERROR_URI
+                if exc.state:
+                    query["state"] = exc.state
                 location = build_uri(request.query.redirect_uri, query)
                 return Response(
                     status_code=HTTPStatus.FOUND,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,7 +4,7 @@ from typing import Any, Callable, Dict, Union
 
 from aioauth.collections import HTTPHeaderDict
 from aioauth.constances import default_headers
-from aioauth.requests import Post, Query, Request
+from aioauth.requests import BaseRequest, Post, Query
 from aioauth.responses import ErrorResponse, Response
 
 EMPTY_KEYS = {
@@ -298,7 +298,7 @@ def get_keys(query: Union[Query, Post]) -> Dict[str, Any]:
 
 
 async def check_query_values(
-    request: Request, responses, query_dict: Dict, endpoint_func, value
+    request: BaseRequest, responses, query_dict: Dict, endpoint_func, value
 ):
     keys = set(query_dict.keys()) & set(responses.keys())
 
@@ -333,7 +333,7 @@ async def check_query_values(
 
 
 async def check_request_validators(
-    request: Request,
+    request: BaseRequest,
     endpoint_func: Callable,
 ):
     query_dict = {}

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -314,6 +314,17 @@ async def check_query_values(
             request_ = replace(request_, query=query)
 
         response_expected = responses[key]
+
+        if (
+            request_.method == "GET"
+            and request_.query.state
+            and response_expected.status_code == HTTPStatus.FOUND
+        ):
+            # error redirects should include the state parameter
+            headers = HTTPHeaderDict(**response_expected.headers)
+            headers["location"] += f"&state={request_.query.state}"
+            response_expected = replace(response_expected, headers=headers)
+
         response_actual = await endpoint_func(request_)
 
         assert (


### PR DESCRIPTION
This adds a new OIDC BaseRequest class which is generic on the User type, unlike the existing OIDC Request class which hardcodes the User type to Any. This allows you to create a subclass of BaseRequest with a particular User type, just like you can do with the non-OIDC version of the BaseRequest class.