### PR TITLE
Make User generic in OIDC Request class

### DIFF
--- a/aioauth/oidc/core/requests.py
+++ b/aioauth/oidc/core/requests.py
@@ -2,11 +2,17 @@ from dataclasses import dataclass, field
 
 from typing import Any, Optional, TypeVar
 
-from aioauth.requests import BaseRequest, Query as BaseQuery, Post
+from aioauth.requests import (
+    BaseRequest as BaseOAuth2Request,
+    Query as OAuth2Query,
+    Post,
+    TPost,
+    TUser,
+)
 
 
 @dataclass
-class Query(BaseQuery):
+class Query(OAuth2Query):
     # Space delimited, case sensitive list of ASCII string values that
     # specifies whether the Authorization Server prompts the End-User for
     # reauthentication and consent. The defined values are: none, login,
@@ -15,17 +21,29 @@ class Query(BaseQuery):
     prompt: Optional[str] = None
 
 
+TQuery = TypeVar("TQuery", bound=Query)
+
+
 @dataclass
-class Request(BaseRequest[Query, Post, Any]):
+class BaseRequest(BaseOAuth2Request[TQuery, TPost, TUser]):
     """
     Object that contains a client's complete request with extensions as defined
     by OpenID Core.
     https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest
     """
 
+    query: TQuery
+    post: TPost
+    user: Optional[TUser] = None
+
+
+TRequest = TypeVar("TRequest", bound=BaseRequest)
+
+
+@dataclass
+class Request(BaseRequest[Query, Post, Any]):
+    """Object that contains a client's complete request."""
+
     query: Query = field(default_factory=Query)
     post: Post = field(default_factory=Post)
     user: Optional[Any] = None
-
-
-TRequest = TypeVar("TRequest", bound=Request)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,7 +4,7 @@ from typing import Any, Callable, Dict, Union
 
 from aioauth.collections import HTTPHeaderDict
 from aioauth.constances import default_headers
-from aioauth.requests import Post, Query, Request
+from aioauth.requests import BaseRequest, Post, Query
 from aioauth.responses import ErrorResponse, Response
 
 EMPTY_KEYS = {
@@ -298,7 +298,7 @@ def get_keys(query: Union[Query, Post]) -> Dict[str, Any]:
 
 
 async def check_query_values(
-    request: Request, responses, query_dict: Dict, endpoint_func, value
+    request: BaseRequest, responses, query_dict: Dict, endpoint_func, value
 ):
     keys = set(query_dict.keys()) & set(responses.keys())
 
@@ -322,7 +322,7 @@ async def check_query_values(
 
 
 async def check_request_validators(
-    request: Request,
+    request: BaseRequest,
     endpoint_func: Callable,
 ):
     query_dict = {}


### PR DESCRIPTION
This adds a new OIDC BaseRequest class which is generic on the User type, unlike the existing OIDC Request class which hardcodes the User type to Any. This allows you to create a subclass of BaseRequest with a particular User type, just like you can do with the non-OIDC version of the BaseRequest class.

This is the same change as in #95 but with some extra commits removed that were accidentally included in the other PR. Sorry about that