### PR TITLE
Refactor storage to follow interface segregation principle

### DIFF
--- a/aioauth/grant_type.py
+++ b/aioauth/grant_type.py
@@ -20,14 +20,14 @@ from .errors import (
 from .models import Client
 from .requests import TRequest
 from .responses import TokenResponse
-from .storage import TStorage
+from .storage import TokenStorage, AuthorizationCodeStorage, ClientStorage, UserStorage
 from .utils import enforce_list, enforce_str, generate_token
 
 
-class GrantTypeBase(Generic[TRequest, TStorage]):
+class GrantTypeBase(Generic[TRequest, TokenStorage]):
     """Base grant type that all other grant types inherit from."""
 
-    def __init__(self, storage: TStorage, client_id: str, client_secret: Optional[str]):
+    def __init__(self, storage: TokenStorage, client_id: str, client_secret: Optional[str]):
         self.storage = storage
         self.client_id = client_id
         self.client_secret = client_secret
@@ -78,7 +78,7 @@ class GrantTypeBase(Generic[TRequest, TStorage]):
         return client
 
 
-class AuthorizationCodeGrantType(GrantTypeBase[TRequest, TStorage]):
+class AuthorizationCodeGrantType(GrantTypeBase[TRequest, AuthorizationCodeStorage]):
     """
     The Authorization Code grant type is used by confidential and public
     clients to exchange an authorization code for an access token. After
@@ -154,7 +154,7 @@ class AuthorizationCodeGrantType(GrantTypeBase[TRequest, TStorage]):
         return token_response
 
 
-class PasswordGrantType(GrantTypeBase[TRequest, TStorage]):
+class PasswordGrantType(GrantTypeBase[TRequest, UserStorage]):
     """
     The Password grant type is a way to exchange a user's credentials
     for an access token. Because the client application has to collect
@@ -183,7 +183,7 @@ class PasswordGrantType(GrantTypeBase[TRequest, TStorage]):
         return client
 
 
-class RefreshTokenGrantType(GrantTypeBase[TRequest, TStorage]):
+class RefreshTokenGrantType(GrantTypeBase[TRequest, TokenStorage]):
     """
     The Refresh Token grant type is used by clients to exchange a
     refresh token for an access token when the access token has expired.
@@ -246,7 +246,7 @@ class RefreshTokenGrantType(GrantTypeBase[TRequest, TStorage]):
         return client
 
 
-class ClientCredentialsGrantType(GrantTypeBase[TRequest, TStorage]):
+class ClientCredentialsGrantType(GrantTypeBase[TRequest, ClientStorage]):
     """
     The Client Credentials grant type is used by clients to obtain an
     access token outside of the context of a user. This is typically

--- a/aioauth/response_type.py
+++ b/aioauth/response_type.py
@@ -31,14 +31,14 @@ from .responses import (
     NoneResponse,
     TokenResponse,
 )
-from .storage import TStorage
+from .storage import AuthorizationCodeStorage, ClientStorage, TokenStorage
 from .types import CodeChallengeMethod
 
 
-class ResponseTypeBase(Generic[TRequest, TStorage]):
+class ResponseTypeBase(Generic[TRequest, ClientStorage]):
     """Base response type that all other exceptions inherit from."""
 
-    def __init__(self, storage: TStorage):
+    def __init__(self, storage: ClientStorage):
         self.storage = storage
 
     async def validate_request(self, request: TRequest) -> Client:
@@ -101,8 +101,11 @@ class ResponseTypeBase(Generic[TRequest, TStorage]):
         return client
 
 
-class ResponseTypeToken(ResponseTypeBase[TRequest, TStorage]):
+class ResponseTypeToken(ResponseTypeBase[TRequest, TokenStorage]):
     """Response type that contains a token."""
+
+    def __init__(self, storage: TokenStorage):
+        self.storage = storage
 
     async def create_authorization_response(
         self, request: TRequest, client: Client
@@ -124,8 +127,11 @@ class ResponseTypeToken(ResponseTypeBase[TRequest, TStorage]):
         )
 
 
-class ResponseTypeAuthorizationCode(ResponseTypeBase[TRequest, TStorage]):
+class ResponseTypeAuthorizationCode(ResponseTypeBase[TRequest, AuthorizationCodeStorage]):
     """Response type that contains an authorization code."""
+
+    def __init__(self, storage: AuthorizationCodeStorage):
+        self.storage = storage
 
     async def create_authorization_response(
         self, request: TRequest, client: Client
@@ -147,7 +153,10 @@ class ResponseTypeAuthorizationCode(ResponseTypeBase[TRequest, TStorage]):
         )
 
 
-class ResponseTypeIdToken(ResponseTypeBase[TRequest, TStorage]):
+class ResponseTypeIdToken(ResponseTypeBase[TRequest, AuthorizationCodeStorage]):
+    def __init__(self, storage: AuthorizationCodeStorage):
+        self.storage = storage
+
     async def validate_request(self, request: TRequest) -> Client:
         client = await super().validate_request(request)
 
@@ -175,7 +184,7 @@ class ResponseTypeIdToken(ResponseTypeBase[TRequest, TStorage]):
         return IdTokenResponse(id_token=id_token)
 
 
-class ResponseTypeNone(ResponseTypeBase[TRequest, TStorage]):
+class ResponseTypeNone(ResponseTypeBase[TRequest, ClientStorage]):
     async def create_authorization_response(
         self, request: TRequest, client: Client
     ) -> NoneResponse:

--- a/aioauth/server.py
+++ b/aioauth/server.py
@@ -59,7 +59,7 @@ from .responses import (
     TokenActiveIntrospectionResponse,
     TokenInactiveIntrospectionResponse,
 )
-from .storage import TStorage
+from .storage import TokenStorage, AuthorizationCodeStorage, ClientStorage, UserStorage
 from .types import (
     GrantType,
     RequestMethod,
@@ -74,25 +74,25 @@ from .utils import (
 )
 
 
-class AuthorizationServer(Generic[TRequest, TStorage]):
+class AuthorizationServer(Generic[TRequest, TokenStorage, AuthorizationCodeStorage, ClientStorage, UserStorage]):
     """Interface for initializing an OAuth 2.0 server."""
 
     response_types: Dict[ResponseType, Any] = {
-        "token": ResponseTypeToken[TRequest, TStorage],
-        "code": ResponseTypeAuthorizationCode[TRequest, TStorage],
-        "none": ResponseTypeNone[TRequest, TStorage],
-        "id_token": ResponseTypeIdToken[TRequest, TStorage],
+        "token": ResponseTypeToken[TRequest, TokenStorage],
+        "code": ResponseTypeAuthorizationCode[TRequest, AuthorizationCodeStorage],
+        "none": ResponseTypeNone[TRequest, ClientStorage],
+        "id_token": ResponseTypeIdToken[TRequest, AuthorizationCodeStorage],
     }
     grant_types: Dict[GrantType, Any] = {
-        "authorization_code": AuthorizationCodeGrantType[TRequest, TStorage],
-        "client_credentials": ClientCredentialsGrantType[TRequest, TStorage],
-        "password": PasswordGrantType[TRequest, TStorage],
-        "refresh_token": RefreshTokenGrantType[TRequest, TStorage],
+        "authorization_code": AuthorizationCodeGrantType[TRequest, AuthorizationCodeStorage],
+        "client_credentials": ClientCredentialsGrantType[TRequest, ClientStorage],
+        "password": PasswordGrantType[TRequest, UserStorage],
+        "refresh_token": RefreshTokenGrantType[TRequest, TokenStorage],
     }
 
     def __init__(
         self,
-        storage: TStorage,
+        storage: Union[TokenStorage, AuthorizationCodeStorage, ClientStorage, UserStorage],
         response_types: Optional[Dict] = None,
         grant_types: Optional[Dict] = None,
     ):
@@ -306,11 +306,11 @@ class AuthorizationServer(Generic[TRequest, TStorage]):
 
         GrantTypeClass: Type[
             Union[
-                GrantTypeBase[TRequest, TStorage],
-                AuthorizationCodeGrantType[TRequest, TStorage],
-                PasswordGrantType[TRequest, TStorage],
-                RefreshTokenGrantType[TRequest, TStorage],
-                ClientCredentialsGrantType[TRequest, TStorage],
+                GrantTypeBase[TRequest, TokenStorage],
+                AuthorizationCodeGrantType[TRequest, AuthorizationCodeStorage],
+                PasswordGrantType[TRequest, UserStorage],
+                RefreshTokenGrantType[TRequest, TokenStorage],
+                ClientCredentialsGrantType[TRequest, ClientStorage],
             ]
         ]
 

--- a/aioauth/storage.py
+++ b/aioauth/storage.py
@@ -17,7 +17,7 @@ from .models import TToken, TClient, TAuthorizationCode
 from .requests import TRequest
 
 
-class BaseStorage(Generic[TToken, TClient, TAuthorizationCode, TRequest]):
+class TokenStorage(Generic[TToken, TRequest]):
     async def create_token(
         self,
         request: TRequest,
@@ -26,20 +26,6 @@ class BaseStorage(Generic[TToken, TClient, TAuthorizationCode, TRequest]):
         access_token: str,
         refresh_token: str,
     ) -> TToken:
-        """Generates a user token and stores it in the database.
-
-        Warning:
-            Generated token *must* be stored in the database.
-        Note:
-            Method is used by all core grant types, but only used for
-            :py:class:`aioauth.response_type.ResponseTypeToken`.
-        Args:
-            request: An :py:class:`aioauth.requests.Request`.
-            client_id: A user client ID.
-            scope: The scopes for the token.
-        Returns:
-            The new generated :py:class:`aioauth.models.Token`.
-        """
         raise NotImplementedError("Method create_token must be implemented")
 
     async def get_token(
@@ -50,22 +36,19 @@ class BaseStorage(Generic[TToken, TClient, TAuthorizationCode, TRequest]):
         access_token: Optional[str] = None,
         refresh_token: Optional[str] = None,
     ) -> Optional[TToken]:
-        """Gets existing token from the database.
-
-        Note:
-            Method is used by
-            :py:class:`aioauth.server.AuthorizationServer`,  and by the
-            grant type :py:class:`aioauth.grant_types.RefreshTokenGrantType`.
-        Args:
-            request: An :py:class:`aioauth.requests.Request`.
-            client_id: A user client ID.
-            access_token: The user access token.
-            refresh_token: The user refresh token.
-        Returns:
-            An optional :py:class:`aioauth.models.Token` object.
-        """
         raise NotImplementedError("Method get_token must be implemented")
 
+    async def revoke_token(
+        self,
+        request: TRequest,
+        token_type: Optional[TokenType] = "refresh_token",
+        access_token: Optional[str] = None,
+        refresh_token: Optional[str] = None,
+    ) -> None:
+        raise NotImplementedError("Method revoke_token must be implemented")
+
+
+class AuthorizationCodeStorage(Generic[TAuthorizationCode, TRequest]):
     async def create_authorization_code(
         self,
         request: TRequest,
@@ -78,100 +61,13 @@ class BaseStorage(Generic[TToken, TClient, TAuthorizationCode, TRequest]):
         code: str,
         **kwargs,
     ) -> TAuthorizationCode:
-        """Generates an authorization token and stores it in the database.
-
-        Warning:
-            Generated authorization token *must* be stored in the database.
-        Note:
-            This must is used by the response type
-            :py:class:`aioauth.respose_type.ResponseTypeAuthorizationCode`.
-        Args:
-            request: An :py:class:`aioauth.requests.Request`.
-            client_id: A user client ID.
-            scope: The scopes for the token.
-            response_type: An :py:class:`aioauth.types.ResponseType`.
-            redirect_uri: The redirect URI.
-            code_challenge_method: An :py:class:`aioauth.types.CodeChallengeMethod`.
-            code_challenge: Code challenge string.
-        Returns:
-            An :py:class:`aioauth.models.AuthorizationCode` object.
-        """
         raise NotImplementedError(
             "Method create_authorization_code must be implemented"
         )
 
-    async def get_id_token(
-        self,
-        request: TRequest,
-        client_id: str,
-        scope: str,
-        response_type: ResponseType,
-        redirect_uri: str,
-        **kwargs,
-    ) -> str:
-        """Returns an id_token.
-        For more information see `OpenID Connect Core 1.0 incorporating errata set 1 section 2 <https://openid.net/specs/openid-connect-core-1_0.html#IDToken>`_.
-
-        Note:
-            Method is used by response type :py:class:`aioauth.response_type.ResponseTypeIdToken`
-            and :py:class:`aioauth.oidc.core.grant_type.AuthorizationCodeGrantType`.
-        """
-        raise NotImplementedError("get_id_token must be implemented.")
-
-    async def get_client(
-        self, request: TRequest, client_id: str, client_secret: Optional[str] = None
-    ) -> Optional[TClient]:
-        """Gets existing client from the database if it exists.
-
-        Warning:
-            If client does not exists in database this method *must*
-            return ``None`` to indicate to the validator that the
-            requested ``client_id`` does not exist or is invalid.
-        Note:
-            This method is used by all core grant types, as well as
-            all core response types.
-        Args:
-            request: An :py:class:`aioauth.requests.Request`.
-            client_id: A user client ID.
-            client_secret: An optional user client secret.
-        Returns:
-            An optional :py:class:`aioauth.models.Client` object.
-        """
-        raise NotImplementedError("Method get_client must be implemented")
-
-    async def authenticate(self, request: TRequest) -> bool:
-        """Authenticates a user.
-
-        Note:
-            This method is used by the grant type
-            :py:class:`aioauth.grant_type.PasswordGrantType`.
-        Args:
-            request: An :py:class:`aioauth.requests.Request`.
-        Returns:
-            Boolean indicating whether or not the user was authenticated
-            successfully.
-        """
-        raise NotImplementedError("Method authenticate must be implemented")
-
     async def get_authorization_code(
         self, request: TRequest, client_id: str, code: str
     ) -> Optional[TAuthorizationCode]:
-        """Gets existing authorization code from the database if it exists.
-
-        Warning:
-            If authorization code does not exists this function *must*
-            return ``None`` to indicate to the validator that the
-            requested authorization code does not exist or is invalid.
-        Note:
-            This method is used by the grant type
-            :py:class:`aioauth.grant_type.AuthorizationCodeGrantType`.
-        Args:
-            request: An :py:class:`aioauth.requests.Request`.
-            client_id: A user client ID.
-            code: An authorization code.
-        Returns:
-            An optional :py:class:`aioauth.models.AuthorizationCode`.
-        """
         raise NotImplementedError(
             "Method get_authorization_code must be implemented for AuthorizationCodeGrantType"
         )
@@ -179,40 +75,24 @@ class BaseStorage(Generic[TToken, TClient, TAuthorizationCode, TRequest]):
     async def delete_authorization_code(
         self, request: TRequest, client_id: str, code: str
     ) -> None:
-        """Deletes authorization code from database.
-
-        Note:
-            This method is used by the grant type
-            :py:class:`aioauth.grant_type.AuthorizationCodeGrantType`.
-        Args:
-            request: An :py:class:`aioauth.requests.Request`.
-            client_id: A user client ID.
-            code: An authorization code.
-        """
         raise NotImplementedError(
             "Method delete_authorization_code must be implemented for AuthorizationCodeGrantType"
         )
 
-    async def revoke_token(
-        self,
-        request: TRequest,
-        token_type: Optional[TokenType] = "refresh_token",
-        access_token: Optional[str] = None,
-        refresh_token: Optional[str] = None,
-    ) -> None:
-        """Revokes a token's from the database.
 
-        Note:
-            This method *must* set ``revoked`` to ``True`` for an
-            existing token record. This method is used by the grant type
-            :py:class:`aioauth.grant_types.RefreshTokenGrantType`.
-        Args:
-            request: An :py:class:`aioauth.requests.Request`.
-            refresh_token: The user refresh token.
-        """
-        raise NotImplementedError(
-            "Method revoke_token must be implemented for RefreshTokenGrantType"
-        )
+class ClientStorage(Generic[TClient, TRequest]):
+    async def get_client(
+        self, request: TRequest, client_id: str, client_secret: Optional[str] = None
+    ) -> Optional[TClient]:
+        raise NotImplementedError("Method get_client must be implemented")
 
 
-TStorage = TypeVar("TStorage", bound=BaseStorage)
+class UserStorage(Generic[TRequest]):
+    async def authenticate(self, request: TRequest) -> bool:
+        raise NotImplementedError("Method authenticate must be implemented")
+
+
+TStorage = TypeVar("TStorage", bound=TokenStorage)
+TStorage = TypeVar("TStorage", bound=AuthorizationCodeStorage)
+TStorage = TypeVar("TStorage", bound=ClientStorage)
+TStorage = TypeVar("TStorage", bound=UserStorage)

--- a/tests/classes.py
+++ b/tests/classes.py
@@ -9,7 +9,7 @@ from aioauth.config import Settings
 from aioauth.models import AuthorizationCode, Client, Token
 from aioauth.requests import BaseRequest, Post, Query, TRequest
 from aioauth.server import AuthorizationServer
-from aioauth.storage import BaseStorage
+from aioauth.storage import TokenStorage, AuthorizationCodeStorage, ClientStorage, UserStorage
 from aioauth.types import CodeChallengeMethod, GrantType, ResponseType, TokenType
 
 if sys.version_info >= (3, 8):
@@ -29,7 +29,7 @@ class Request(BaseRequest[Query, Post, User]):
     ...
 
 
-class Storage(BaseStorage[Token, Client, AuthorizationCode, Request]):
+class Storage(TokenStorage[Token, Request], AuthorizationCodeStorage[AuthorizationCode, Request], ClientStorage[Client, Request], UserStorage[Request]):
     def __init__(
         self,
         authorization_codes: List[AuthorizationCode],


### PR DESCRIPTION
Separate methods in storage to follow the interface segregation principle from SOLID.

* **aioauth/storage.py**
  - Remove `BaseStorage` class.
  - Add `TokenStorage` interface with methods `create_token`, `get_token`, and `revoke_token`.
  - Add `AuthorizationCodeStorage` interface with methods `create_authorization_code`, `get_authorization_code`, and `delete_authorization_code`.
  - Add `ClientStorage` interface with method `get_client`.
  - Add `UserStorage` interface with method `authenticate`.

* **tests/classes.py**
  - Update `Storage` class to implement `TokenStorage`, `AuthorizationCodeStorage`, `ClientStorage`, and `UserStorage` interfaces.

* **aioauth/grant_type.py**
  - Update `GrantTypeBase` class to use `TokenStorage` interface.
  - Update `AuthorizationCodeGrantType` class to use `AuthorizationCodeStorage` interface.
  - Update `PasswordGrantType` class to use `UserStorage` interface.
  - Update `RefreshTokenGrantType` class to use `TokenStorage` interface.
  - Update `ClientCredentialsGrantType` class to use `ClientStorage` interface.

* **aioauth/response_type.py**
  - Update `ResponseTypeBase` class to use `ClientStorage` interface.
  - Update `ResponseTypeToken` class to use `TokenStorage` interface.
  - Update `ResponseTypeAuthorizationCode` class to use `AuthorizationCodeStorage` interface.
  - Update `ResponseTypeIdToken` class to use `AuthorizationCodeStorage` interface.
  - Update `ResponseTypeNone` class to use `ClientStorage` interface.

* **aioauth/server.py**
  - Update `AuthorizationServer` class to use `TokenStorage`, `AuthorizationCodeStorage`, `ClientStorage`, and `UserStorage` interfaces.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/aliev/aioauth?shareId=75860988-8988-47c2-87de-d5216e510ff4).