### PR TITLE
Optional refresh token in implicit grant

### DIFF
--- a/aioauth/config.py
+++ b/aioauth/config.py
@@ -21,6 +21,33 @@ class Settings:
     REFRESH_TOKEN_EXPIRES_IN: int = TOKEN_EXPIRES_IN * 2
     """Refresh token lifetime in seconds. Defaults to TOKEN_EXPIRES_IN * 2 (48 hours)."""
 
+    ISSUE_REFRESH_TOKEN_IMPLICIT_GRANT: bool = True
+    """Issue refresh tokens during implicit grant dialog.
+
+    Note:
+        This flag can be used, when sets to `True`, to strictly meet the requirements
+        described in section 4.2 of the RFC 6749 regarding the issuance of refresh
+        tokens during grant type "Implicit Grant". In particular, as stated in section
+        4.2.2 of that RFC:
+
+        > 4.2.2.  Access Token Response
+        >
+        > If the resource owner grants the access request, the authorization
+        > server issues an access token and delivers it to the client by adding
+        > the following parameters to the fragment component of the redirection
+        > URI using the "application/x-www-form-urlencoded" format, per
+        > Appendix B:
+        >
+        > [...]
+        >
+        > The authorization server MUST NOT issue a refresh token.
+
+        Reference links:
+
+        - https://datatracker.ietf.org/doc/html/rfc6749#section-4.2
+        - https://datatracker.ietf.org/doc/html/rfc6749#section-4.2.2
+    """
+
     AUTHORIZATION_CODE_EXPIRES_IN: int = 5 * 60
     """Authorization code lifetime in seconds. Defaults to 5 minutes."""
 

--- a/aioauth/response_type.py
+++ b/aioauth/response_type.py
@@ -7,6 +7,7 @@ Response objects used throughout the project.
 
 ----
 """
+
 import sys
 from typing import Generic, Tuple
 
@@ -112,8 +113,19 @@ class ResponseTypeToken(ResponseTypeBase[TRequest, TStorage]):
             client.client_id,
             request.query.scope,
             generate_token(42),
-            generate_token(48),
+            (
+                generate_token(48)
+                if request.settings.ISSUE_REFRESH_TOKEN_IMPLICIT_GRANT
+                else None
+            ),
         )
+        if not request.settings.ISSUE_REFRESH_TOKEN_IMPLICIT_GRANT:
+            return TokenResponse(
+                expires_in=token.expires_in,
+                access_token=token.access_token,
+                scope=token.scope,
+                token_type=token.token_type,
+            )
         return TokenResponse(
             expires_in=token.expires_in,
             refresh_token_expires_in=token.refresh_token_expires_in,

--- a/aioauth/responses.py
+++ b/aioauth/responses.py
@@ -9,7 +9,7 @@ Response objects used throughout the project.
 """
 from dataclasses import dataclass, field
 from http import HTTPStatus
-from typing import Dict
+from typing import Dict, Optional
 
 from .collections import HTTPHeaderDict
 from .constances import default_headers
@@ -52,10 +52,10 @@ class TokenResponse:
     """
 
     expires_in: int
-    refresh_token_expires_in: int
     access_token: str
-    refresh_token: str
     scope: str
+    refresh_token_expires_in: Optional[int] = None
+    refresh_token: Optional[str] = None
     token_type: str = "Bearer"
 
 

--- a/aioauth/server.py
+++ b/aioauth/server.py
@@ -16,6 +16,7 @@ Warning:
 
 ----
 """
+
 import sys
 from dataclasses import asdict
 from http import HTTPStatus
@@ -417,7 +418,16 @@ class AuthorizationServer(Generic[TRequest, TStorage]):
             response = await response_type.create_authorization_response(
                 request, client
             )
-            responses.update(asdict(response))
+            response_asdict = asdict(response)
+            if (
+                isinstance(response_type, ResponseTypeToken)
+                and not request.settings.ISSUE_REFRESH_TOKEN_IMPLICIT_GRANT
+            ):
+                # This is the implicit grant where the generation of refresh token has
+                # been disabled in settings
+                response_asdict.pop("refresh_token")
+                response_asdict.pop("refresh_token_expires_in")
+            responses.update(response_asdict)
 
         # See: https://openid.net/specs/oauth-v2-multiple-response-types-1_0.html#Combinations
         if "code" in response_type_list:

--- a/aioauth/storage.py
+++ b/aioauth/storage.py
@@ -24,7 +24,7 @@ class BaseStorage(Generic[TToken, TClient, TAuthorizationCode, TRequest]):
         client_id: str,
         scope: str,
         access_token: str,
-        refresh_token: str,
+        refresh_token: Optional[str] = None,
     ) -> TToken:
         """Generates a user token and stores it in the database.
 

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -3,6 +3,7 @@ from urllib.parse import parse_qsl, urlparse
 
 import pytest
 
+from aioauth.config import Settings
 from aioauth.constances import default_headers
 from aioauth.requests import Post, Query, Request
 from aioauth.utils import (
@@ -215,9 +216,17 @@ async def test_authorization_code_flow_pkce_code_challenge():
 
 
 @pytest.mark.asyncio
-async def test_implicit_flow(context_factory):
+@pytest.mark.parametrize(
+    ids=["default_settings", "no_issue_refresh_token_implicit"],
+    argnames="settings",
+    argvalues=[None, Settings(ISSUE_REFRESH_TOKEN_IMPLICIT_GRANT=False)],
+)
+async def test_implicit_flow(context_factory, settings):
     username = "username"
-    context = context_factory(users={username: "password"})
+    context = context_factory(
+        users={username: "password"},
+        settings=settings,
+    )
     server = context.server
     client = context.clients[0]
     request_url = "https://localhost"
@@ -237,6 +246,7 @@ async def test_implicit_flow(context_factory):
         query=query,
         method="GET",
         user=username,
+        settings=context.settings,
     )
 
     response = await server.create_authorization_response(request)
@@ -500,9 +510,17 @@ async def test_client_credentials_flow_auth_header(context: AuthorizationContext
 
 
 @pytest.mark.asyncio
-async def test_multiple_response_types(context_factory):
+@pytest.mark.parametrize(
+    ids=["default_settings", "no_issue_refresh_token_implicit"],
+    argnames="settings",
+    argvalues=[None, Settings(ISSUE_REFRESH_TOKEN_IMPLICIT_GRANT=False)],
+)
+async def test_multiple_response_types(context_factory, settings):
     username = "username"
-    context = context_factory(users={username: "password"})
+    context = context_factory(
+        users={username: "password"},
+        settings=Settings(ISSUE_REFRESH_TOKEN_IMPLICIT_GRANT=False),
+    )
     server = context.server
     client = context.clients[0]
     request_url = "https://localhost"
@@ -520,6 +538,7 @@ async def test_multiple_response_types(context_factory):
         query=query,
         method="GET",
         user=username,
+        settings=context.settings,
     )
 
     await check_request_validators(request, server.create_authorization_response)
@@ -532,12 +551,16 @@ async def test_multiple_response_types(context_factory):
 
     assert "state" in fragment
     assert "expires_in" in fragment
-    assert "refresh_token_expires_in" in fragment
     assert "access_token" in fragment
-    assert "refresh_token" in fragment
     assert "scope" in fragment
     assert "token_type" in fragment
     assert "code" in fragment
+    if context.settings.ISSUE_REFRESH_TOKEN_IMPLICIT_GRANT:
+        assert "refresh_token_expires_in" in fragment
+        assert "refresh_token" in fragment
+    else:
+        assert "refresh_token_expires_in" not in fragment
+        assert "refresh_token" not in fragment
 
 
 @pytest.mark.asyncio
@@ -577,6 +600,11 @@ async def test_response_type_none(context_factory):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
+    ids=["default_settings", "no_issue_refresh_token_implicit"],
+    argnames="settings",
+    argvalues=[None, Settings(ISSUE_REFRESH_TOKEN_IMPLICIT_GRANT=False)],
+)
+@pytest.mark.parametrize(
     "response_mode,",
     [
         "query",
@@ -585,9 +613,12 @@ async def test_response_type_none(context_factory):
         None,
     ],
 )
-async def test_response_type_id_token(context_factory, response_mode):
+async def test_response_type_id_token(context_factory, response_mode, settings):
     username = "username"
-    context = context_factory(users={username: "password"})
+    context = context_factory(
+        users={username: "password"},
+        settings=settings,
+    )
     server = context.server
     client = context.clients[0]
     request_url = "https://localhost"
@@ -607,6 +638,7 @@ async def test_response_type_id_token(context_factory, response_mode):
         query=query,
         method="GET",
         user=username,
+        settings=context.settings,
     )
 
     await check_request_validators(request, server.create_authorization_response)
@@ -618,43 +650,47 @@ async def test_response_type_id_token(context_factory, response_mode):
     fragment = dict(parse_qsl(location.fragment))
     query = dict(parse_qsl(location.query))
 
-    if response_mode == "fragment":
+    if response_mode == "fragment" or response_mode is None:
         assert "state" in fragment
         assert "expires_in" in fragment
-        assert "refresh_token_expires_in" in fragment
         assert "access_token" in fragment
-        assert "refresh_token" in fragment
         assert "scope" in fragment
         assert "token_type" in fragment
         assert "code" in fragment
         assert "id_token" in fragment
+        if context.settings.ISSUE_REFRESH_TOKEN_IMPLICIT_GRANT:
+            assert "refresh_token_expires_in" in fragment
+            assert "refresh_token" in fragment
+        else:
+            assert "refresh_token_expires_in" not in fragment
+            assert "refresh_token" not in fragment
     elif response_mode == "form_post":
         assert "state" in response.content
         assert "expires_in" in response.content
-        assert "refresh_token_expires_in" in response.content
         assert "access_token" in response.content
-        assert "refresh_token" in response.content
         assert "scope" in response.content
         assert "token_type" in response.content
         assert "code" in response.content
         assert "id_token" in response.content
+        if context.settings.ISSUE_REFRESH_TOKEN_IMPLICIT_GRANT:
+            assert "refresh_token" in response.content
+            assert "refresh_token_expires_in" in response.content
+        else:
+            assert "refresh_token" not in response.content
+            assert "refresh_token_expires_in" not in response.content
     elif response_mode == "query":
         assert "state" in query
         assert "expires_in" in query
-        assert "refresh_token_expires_in" in query
         assert "access_token" in query
-        assert "refresh_token" in query
         assert "scope" in query
         assert "token_type" in query
         assert "code" in query
         assert "id_token" in query
+        if context.settings.ISSUE_REFRESH_TOKEN_IMPLICIT_GRANT:
+            assert "refresh_token" in query
+            assert "refresh_token_expires_in" in query
+        else:
+            assert "refresh_token" not in query
+            assert "refresh_token_expires_in" not in query
     else:
-        assert "state" in fragment
-        assert "expires_in" in fragment
-        assert "refresh_token_expires_in" in fragment
-        assert "access_token" in fragment
-        assert "refresh_token" in fragment
-        assert "scope" in fragment
-        assert "token_type" in fragment
-        assert "code" in fragment
-        assert "id_token" in fragment
+        raise AssertionError("Unexpected value of response_mode")


### PR DESCRIPTION
Solution proposal for issues: #98.

This commit includes additional logic to make the generation of refresh tokens optional in implicit grant flows so that this package becomes strictly compliant with the OAuth 2.0 specification in section 4.2. To see further information, please refer to issue #98.

To not break backward compatibility, this new option has been included as an new optional setting flag, `ISSUE_REFRESH_TOKEN_IMPLICIT_GRANT`, that when set to `False`, it deactivates the refresh token generation in implicit flows.