### PR TITLE
feat: support for building custom error-responses

### DIFF
--- a/aioauth/errors.py
+++ b/aioauth/errors.py
@@ -214,3 +214,11 @@ class UnsupportedTokenTypeError(Generic[UserType], OAuth2Error[UserType]):
     """
 
     error: ErrorType = "unsupported_token_type"
+
+
+class AccessDeniedError(Generic[UserType], OAuth2Error[UserType]):
+    """
+    The resource owner or authorization server denied the request
+    """
+
+    error: ErrorType = "access_denied"

--- a/aioauth/types.py
+++ b/aioauth/types.py
@@ -36,6 +36,7 @@ ErrorType: TypeAlias = Literal[
     "method_is_not_allowed",
     "server_error",
     "temporarily_unavailable",
+    "access_denied",
 ]
 
 

--- a/aioauth/utils.py
+++ b/aioauth/utils.py
@@ -227,6 +227,57 @@ def create_s256_code_challenge(code_verifier: str) -> str:
     return base64.urlsafe_b64encode(data).rstrip(b"=").decode()
 
 
+def build_error_response(
+    exc: Exception,
+    request: Request,
+    skip_redirect_on_exc: Tuple[Type[OAuth2Error], ...] = (OAuth2Error,),
+) -> Response:
+    """
+    Generate an OAuth HTTP response from the given exception
+
+    Args:
+        exc: Exception used to generate HTTP response
+        request: oauth request object
+        skip_redirect_on_exc: Exception types to skip redirect on
+    Returns:
+        OAuth HTTP response
+    """
+    error: Union[TemporarilyUnavailableError, ServerError]
+    if isinstance(exc, skip_redirect_on_exc):
+        content = ErrorResponse(error=exc.error, description=exc.description)
+        log.debug("%s %r", exc, request)
+        return Response(
+            content=asdict(content),
+            status_code=exc.status_code,
+            headers=exc.headers,
+        )
+    if isinstance(exc, OAuth2Error):
+        log.debug("%s %r", exc, request)
+        query: Dict[str, str] = {"error": exc.error}
+        if exc.description:
+            query["error_description"] = exc.description
+        if request.settings.ERROR_URI:
+            query["error_uri"] = request.settings.ERROR_URI
+        if exc.state:
+            query["state"] = exc.state
+        location = build_uri(request.query.redirect_uri, query)
+        return Response(
+            status_code=HTTPStatus.FOUND,
+            headers=HTTPHeaderDict({"location": location}),
+        )
+    error = ServerError(
+        request=request,
+        description=str(exc) if request.settings.DEBUG else "",
+    )
+    log.exception("Exception caught while processing request.", exc_info=exc)
+    content = ErrorResponse(error=error.error, description=error.description)
+    return Response(
+        content=asdict(content),
+        status_code=error.status_code,
+        headers=error.headers,
+    )
+
+
 def catch_errors_and_unavailability(
     skip_redirect_on_exc: Tuple[Type[OAuth2Error], ...] = (OAuth2Error,)
 ) -> Callable[..., Callable[..., Coroutine[Any, Any, Response]]]:
@@ -242,49 +293,12 @@ def catch_errors_and_unavailability(
     def decorator(f) -> Callable[..., Coroutine[Any, Any, Response]]:
         @functools.wraps(f)
         async def wrapper(self, request: Request, *args, **kwargs) -> Response:
-            error: Union[TemporarilyUnavailableError, ServerError]
-
             try:
                 response = await f(self, request, *args, **kwargs)
-            except skip_redirect_on_exc as exc:
-                content = ErrorResponse(error=exc.error, description=exc.description)
-                log.debug("%s %r", exc, request)
-                return Response(
-                    content=asdict(content),
-                    status_code=exc.status_code,
-                    headers=exc.headers,
-                )
-            except OAuth2Error as exc:
-                log.debug("%s %r", exc, request)
-                query: Dict[str, str] = {
-                    "error": exc.error,
-                }
-                if exc.description:
-                    query["error_description"] = exc.description
-                if request.settings.ERROR_URI:
-                    query["error_uri"] = request.settings.ERROR_URI
-                if exc.state:
-                    query["state"] = exc.state
-                location = build_uri(request.query.redirect_uri, query)
-                return Response(
-                    status_code=HTTPStatus.FOUND,
-                    headers=HTTPHeaderDict({"location": location}),
-                )
             except Exception as exc:
-                error = ServerError(
-                    request=request,
-                    description=str(exc) if request.settings.DEBUG else "",
+                response = build_error_response(
+                    exc=exc, request=request, skip_redirect_on_exc=skip_redirect_on_exc
                 )
-                log.exception("Exception caught while processing request.")
-                content = ErrorResponse(
-                    error=error.error, description=error.description
-                )
-                return Response(
-                    content=asdict(content),
-                    status_code=error.status_code,
-                    headers=error.headers,
-                )
-
             return response
 
         return wrapper


### PR DESCRIPTION
features:
  - adds support for `access_denied` error in [oauth2 rfc](https://datatracker.ietf.org/doc/html/rfc6749)
  - allows apis to implement their own custom exceptions (e.g. scope permission approval pages)
  
example:

```python3
import json
from fastapi import FastAPI, Query, Request, Response

from aioauth.server import AuthorizationServer
from aioauth.errors import AccessDeniedError, OAuth2Error
from aioauth.storage import BaseStorage
from aioauth.utils import build_error_response
from aioauth.responses import Response as OAuthResponse

app     = FastAPI()
storage = BaseStorage()
server  = AuthorizationServer(storage)

def to_response(response: OAuthResponse) -> Response:
    """
    convert aioauth oauth2 response into fastapi response
    """
    return Response(
        content=json.dumps(response.content),
        headers=dict(response.headers),
        status_code=response.status_code,
    )

@app.exception_handler(OAuth2Error)
async def oauth_handler(request: Request, exc: OAuth2Error):
    """
    custom fastapi exception handler
    """
    response = build_error_response(exc, exc.request)
    return to_response(response)

@app.get('/approve_scopes')
async def approve(request: Request, approve: bool = Query(False)):
    """
    give user option to approve/deny scopes requested by client
    """
    oauthreq = request.session['oauth']
    if approve is not True:
        raise_error = False
        # raise error and use fastapi exception handler
        error = AccessDeniedError(oauthreq)
        if raise_error:
            raise error
        # otherwise generate response as normal
        response = build_error_response(error, error.request)
        return to_response(response)
    response = await server.create_authorization_response(oauthreq)
    return to_response(response)
```