### PR TITLE
fix: avoid mypy dependency resolution error within example on pre-commit check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,10 @@ explicit_package_bases = true
 [tool.mypy-packages]
 ignore_missing_imports = true
 
+[[tool.mypy.overrides]]
+module = 'shared'
+ignore_missing_imports = true
+
 [tool.flake8]
 ignore = ["D10", "E203", "E501", "W503", "D205", "D400", "A001", "D210", "D401", "E701"]
 max-line-length = 88


### PR DESCRIPTION
fixes a pre-commit and github action error related to mypy's dependency scanning for the new fastapi example.
based on discussion https://github.com/aliev/aioauth/pull/106#issuecomment-2525055518 and https://github.com/aliev/aioauth/pull/106#issuecomment-2525180878

