### PR TITLE
fix(utils): include query-params from base when building uri

### DIFF
--- a/aioauth/utils.py
+++ b/aioauth/utils.py
@@ -29,7 +29,7 @@ from typing import (
     Type,
     Union,
 )
-from urllib.parse import quote, urlencode, urlparse, urlunsplit
+from urllib.parse import parse_qs, quote, urlencode, urlparse, urlunsplit
 
 from aioauth.requests import Request
 
@@ -155,6 +155,9 @@ def build_uri(
         fragment = {}
 
     parsed_url = urlparse(url)
+    parsed_params = {k: v[0] for k, v in parse_qs(parsed_url.query or "").items()}
+    query_params = {**parsed_params, **query_params}
+
     uri = urlunsplit(
         (
             parsed_url.scheme,


### PR DESCRIPTION
Hello again!

I've been using v2 for quite some time now and really enjoying it. Our OAuth server implemented with it is working fantastically! However, I ran into a small issue when attempting to integrate with a wordpress site using an older plugin called "OpenID Connect Client".

The plugin uses a redirect-uri with a configured query-parameter that is essential for the plugin:
`.../wp-admin/admin-ajax.php?action=openid-connect-authorize`. If the action parameter is missing, the redirect just errors with wordpress seemingly unsure what to do with the request, and the login fails.

It turns out aioauth is stripping query-parameters from the configured redirect-uri and just replacing them with the response parameters on response, so this just ensures that the base parameters are included but overwritten by the response ones if required.

After the following changes, the login worked as intended.
Hope this helps, thanks :)